### PR TITLE
Generate reference config from previous logs

### DIFF
--- a/nodescraper/cli/cli.py
+++ b/nodescraper/cli/cli.py
@@ -156,7 +156,7 @@ def build_parser(
         "--gen-reference-config-from-logs",
         dest="reference_config_from_logs",
         type=log_path_arg,
-        help="Generate reference config from previous run. Writes to ./reference_config.json.",
+        help="Generate reference config from previous run logfiles. Writes to ./reference_config.json.",
     )
 
     subparsers = parser.add_subparsers(dest="subcmd", help="Subcommands")

--- a/nodescraper/cli/helper.py
+++ b/nodescraper/cli/helper.py
@@ -323,7 +323,19 @@ def generate_reference_config(
     return plugin_config
 
 
-def generate_reference_config_from_logs(path, plugin_reg, logger):
+def generate_reference_config_from_logs(
+    path: str, plugin_reg: PluginRegistry, logger: logging.Logger
+) -> PluginConfig:
+    """Parse previous log files and generate plugin config with populated analyzer args
+
+    Args:
+        path (str): path to log files
+        plugin_reg (PluginRegistry): plugin registry instance
+        logger (logging.Logger): logger instance
+
+    Returns:
+        PluginConfig: instance of plugin config
+    """
     found = find_datamodel_and_result(path)
     plugin_config = PluginConfig()
     plugins = {}
@@ -331,8 +343,6 @@ def generate_reference_config_from_logs(path, plugin_reg, logger):
         result_path = Path(res)
         res_payload = json.loads(result_path.read_text(encoding="utf-8"))
         task_res = TaskResult(**res_payload)
-        # print(json.dumps(res_payload, indent=2))
-        # print(task_res.parent)
         dm_path = Path(dm)
         dm_payload = json.loads(dm_path.read_text(encoding="utf-8"))
         plugin = plugin_reg.plugins.get(task_res.parent)
@@ -355,14 +365,19 @@ def generate_reference_config_from_logs(path, plugin_reg, logger):
         plugins[task_res.parent] = {"analysis_args": {}}
         plugins[task_res.parent]["analysis_args"] = args.model_dump(exclude_none=True)
 
-        # print("Datamodel:", dm)
-        # print("Result:   ", res)
     plugin_config.plugins = plugins
     return plugin_config
 
 
 def find_datamodel_and_result(base_path: str) -> list[Tuple[str, str]]:
-    """ """
+    """Get datamodel and result files
+
+    Args:
+        base_path (str): location of previous run logs
+
+    Returns:
+        list[Tuple[str, str]]: tuple of datamodel and result json files
+    """
     tuple_list: list[Tuple[str, str, str]] = []
     for root, _, files in os.walk(base_path):
         if "collector" in os.path.basename(root).lower():

--- a/nodescraper/models/taskresult.py
+++ b/nodescraper/models/taskresult.py
@@ -27,7 +27,7 @@ import datetime
 import logging
 from typing import Optional
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from nodescraper.enums import EventPriority, ExecutionStatus
 
@@ -64,6 +64,18 @@ class TaskResult(BaseModel):
             str: status name string
         """
         return status.name
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _coerce_status(cls, v):
+        if isinstance(v, ExecutionStatus):
+            return v
+        if isinstance(v, str):
+            try:
+                return ExecutionStatus[v]
+            except KeyError as err:
+                raise ValueError(f"Unknown status name: {v!r}") from err
+        return v
 
     @property
     def duration(self) -> str | None:

--- a/nodescraper/plugins/inband/storage/storagedata.py
+++ b/nodescraper/plugins/inband/storage/storagedata.py
@@ -23,10 +23,10 @@
 # SOFTWARE.
 #
 ###############################################################################
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, field_serializer, field_validator
 
 from nodescraper.models import DataModel
-from nodescraper.utils import bytes_to_human_readable
+from nodescraper.utils import bytes_to_human_readable, convert_to_bytes
 
 
 class DeviceStorageData(BaseModel):
@@ -50,6 +50,20 @@ class DeviceStorageData(BaseModel):
     @field_serializer("percent")
     def serialize_percent(self, percent: float, _info) -> str:
         return f"{percent}%"
+
+    @field_validator("total", "free", "used", mode="before")
+    @classmethod
+    def parse_bytes_fields(cls, v):
+        if isinstance(v, str):
+            return convert_to_bytes(v)
+        return v
+
+    @field_validator("percent", mode="before")
+    @classmethod
+    def parse_percent_field(cls, v):
+        if isinstance(v, str) and v.endswith("%"):
+            return float(v.rstrip("%"))
+        return v
 
 
 class StorageDataModel(DataModel):

--- a/test/unit/framework/fixtures/log_dir/collector/biosdatamodel.json
+++ b/test/unit/framework/fixtures/log_dir/collector/biosdatamodel.json
@@ -1,0 +1,3 @@
+{
+  "bios_version": "M17"
+}

--- a/test/unit/framework/fixtures/log_dir/collector/result.json
+++ b/test/unit/framework/fixtures/log_dir/collector/result.json
@@ -1,0 +1,8 @@
+{
+  "status": "OK",
+  "message": "BIOS: M17",
+  "task": "BiosCollector",
+  "parent": "BiosPlugin",
+  "start_time": "2025-07-07T11:11:08.186472",
+  "end_time": "2025-07-07T11:11:08.329110"
+}

--- a/test/unit/framework/test_cli.py
+++ b/test/unit/framework/test_cli.py
@@ -24,20 +24,14 @@
 #
 ###############################################################################
 import argparse
-import logging
 import os
 
 import pytest
-from common.shared_utils import DummyDataModel
 from pydantic import BaseModel
 
 from nodescraper.cli import cli, inputargtypes
-from nodescraper.cli.helper import build_config
-from nodescraper.configregistry import ConfigRegistry
-from nodescraper.enums import ExecutionStatus, SystemInteractionLevel, SystemLocation
-from nodescraper.models import PluginConfig, SystemInfo, TaskResult
-from nodescraper.models.datapluginresult import DataPluginResult
-from nodescraper.models.pluginresult import PluginResult
+from nodescraper.enums import SystemLocation
+from nodescraper.models import SystemInfo
 
 
 def test_log_path_arg():
@@ -155,91 +149,3 @@ def test_system_info_builder():
 )
 def test_process_args(raw_arg_input, plugin_names, exp_output):
     assert cli.process_args(raw_arg_input, plugin_names) == exp_output
-
-
-def test_get_plugin_configs():
-    with pytest.raises(argparse.ArgumentTypeError):
-        cli.get_plugin_configs(
-            system_interaction_level="INVALID",
-            plugin_config_input=[],
-            built_in_configs={},
-            parsed_plugin_args={},
-            plugin_subparser_map={},
-        )
-
-    plugin_configs = cli.get_plugin_configs(
-        system_interaction_level="PASSIVE",
-        plugin_config_input=[],
-        built_in_configs={},
-        parsed_plugin_args={
-            "TestPlugin1": argparse.Namespace(arg1="test123"),
-            "TestPlugin2": argparse.Namespace(arg2="testabc", model_arg1="123", model_arg2="abc"),
-        },
-        plugin_subparser_map={
-            "TestPlugin1": (argparse.ArgumentParser(), {}),
-            "TestPlugin2": (
-                argparse.ArgumentParser(),
-                {"model_arg1": "my_model", "model_arg2": "my_model"},
-            ),
-        },
-    )
-
-    assert plugin_configs == [
-        PluginConfig(
-            global_args={"system_interaction_level": SystemInteractionLevel.PASSIVE},
-            plugins={},
-            result_collators={"TableSummary": {}},
-        ),
-        PluginConfig(
-            plugins={
-                "TestPlugin1": {"arg1": "test123"},
-                "TestPlugin2": {
-                    "arg2": "testabc",
-                    "my_model": {"model_arg1": "123", "model_arg2": "abc"},
-                },
-            },
-        ),
-    ]
-
-
-def test_config_builder(plugin_registry):
-
-    config = build_config(
-        config_reg=ConfigRegistry(config_path=os.path.join(os.path.dirname(__file__), "fixtures")),
-        plugin_reg=plugin_registry,
-        logger=logging.getLogger(),
-        plugins=["TestPluginA"],
-        built_in_configs=["ExampleConfig"],
-    )
-    assert config.plugins == {
-        "TestPluginA": {
-            "test_bool_arg": True,
-            "test_str_arg": "test",
-            "test_model_arg": {"model_attr": 123},
-        },
-        "ExamplePlugin": {},
-    }
-
-
-def test_generate_reference_config(plugin_registry):
-    results = [
-        PluginResult(
-            status=ExecutionStatus.OK,
-            source="TestPluginA",
-            message="Plugin tasks completed successfully",
-            result_data=DataPluginResult(
-                system_data=DummyDataModel(some_version="M17"),
-                collection_result=TaskResult(
-                    status=ExecutionStatus.OK,
-                    message="BIOS: M17",
-                    task="BiosCollector",
-                    parent="TestPluginA",
-                    artifacts=[],
-                ),
-            ),
-        )
-    ]
-
-    ref_config = cli.generate_reference_config(results, plugin_registry, logging.getLogger())
-    dump = ref_config.dict()
-    assert dump["plugins"] == {"TestPluginA": {"analysis_args": {"model_attr": 123}}}

--- a/test/unit/framework/test_helper.py
+++ b/test/unit/framework/test_helper.py
@@ -1,0 +1,178 @@
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+###############################################################################
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from common.shared_utils import DummyDataModel
+from pydantic import BaseModel
+
+from nodescraper.cli import cli
+from nodescraper.cli.helper import build_config, find_datamodel_and_result
+from nodescraper.configregistry import ConfigRegistry
+from nodescraper.enums import ExecutionStatus, SystemInteractionLevel
+from nodescraper.models import PluginConfig, TaskResult
+from nodescraper.models.datapluginresult import DataPluginResult
+from nodescraper.models.pluginresult import PluginResult
+
+
+def test_generate_reference_config(plugin_registry):
+    results = [
+        PluginResult(
+            status=ExecutionStatus.OK,
+            source="TestPluginA",
+            message="Plugin tasks completed successfully",
+            result_data=DataPluginResult(
+                system_data=DummyDataModel(some_version="M17"),
+                collection_result=TaskResult(
+                    status=ExecutionStatus.OK,
+                    message="BIOS: M17",
+                    task="BiosCollector",
+                    parent="TestPluginA",
+                    artifacts=[],
+                ),
+            ),
+        )
+    ]
+
+    ref_config = cli.generate_reference_config(results, plugin_registry, logging.getLogger())
+    dump = ref_config.dict()
+    assert dump["plugins"] == {"TestPluginA": {"analysis_args": {"model_attr": 123}}}
+
+
+def test_get_plugin_configs():
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli.get_plugin_configs(
+            system_interaction_level="INVALID",
+            plugin_config_input=[],
+            built_in_configs={},
+            parsed_plugin_args={},
+            plugin_subparser_map={},
+        )
+
+    plugin_configs = cli.get_plugin_configs(
+        system_interaction_level="PASSIVE",
+        plugin_config_input=[],
+        built_in_configs={},
+        parsed_plugin_args={
+            "TestPlugin1": argparse.Namespace(arg1="test123"),
+            "TestPlugin2": argparse.Namespace(arg2="testabc", model_arg1="123", model_arg2="abc"),
+        },
+        plugin_subparser_map={
+            "TestPlugin1": (argparse.ArgumentParser(), {}),
+            "TestPlugin2": (
+                argparse.ArgumentParser(),
+                {"model_arg1": "my_model", "model_arg2": "my_model"},
+            ),
+        },
+    )
+
+    assert plugin_configs == [
+        PluginConfig(
+            global_args={"system_interaction_level": SystemInteractionLevel.PASSIVE},
+            plugins={},
+            result_collators={"TableSummary": {}},
+        ),
+        PluginConfig(
+            plugins={
+                "TestPlugin1": {"arg1": "test123"},
+                "TestPlugin2": {
+                    "arg2": "testabc",
+                    "my_model": {"model_arg1": "123", "model_arg2": "abc"},
+                },
+            },
+        ),
+    ]
+
+
+def test_config_builder(plugin_registry):
+
+    config = build_config(
+        config_reg=ConfigRegistry(config_path=os.path.join(os.path.dirname(__file__), "fixtures")),
+        plugin_reg=plugin_registry,
+        logger=logging.getLogger(),
+        plugins=["TestPluginA"],
+        built_in_configs=["ExampleConfig"],
+    )
+    assert config.plugins == {
+        "TestPluginA": {
+            "test_bool_arg": True,
+            "test_str_arg": "test",
+            "test_model_arg": {"model_attr": 123},
+        },
+        "ExamplePlugin": {},
+    }
+
+
+def test_find_datamodel_and_result_with_fixture(framework_fixtures_path):
+    base_dir = framework_fixtures_path / "log_dir"
+    assert (base_dir / "collector/biosdatamodel.json").exists()
+    assert (base_dir / "collector/result.json").exists()
+
+    pairs = find_datamodel_and_result(str(base_dir))
+    assert len(pairs) == 1
+
+    datamodel_path, result_path = pairs[0]
+    dm = Path(datamodel_path)
+    rt = Path(result_path)
+
+    assert dm.parent == base_dir / "collector"
+    assert rt.parent == base_dir / "collector"
+
+    assert dm.name == "biosdatamodel.json"
+    assert rt.name == "result.json"
+
+
+def test_generate_reference_config_from_logs(framework_fixtures_path):
+    logger = logging.getLogger()
+    res_payload = json.loads(
+        (framework_fixtures_path / "log_dir/collector/result.json").read_text(encoding="utf-8")
+    )
+    parent = res_payload["parent"]
+
+    class FakeDataModel:
+        @classmethod
+        def model_validate(cls, payload):
+            return payload
+
+    class FakeArgs(BaseModel):
+        @classmethod
+        def build_from_model(cls, datamodel):
+            return cls()
+
+    plugin_reg = SimpleNamespace(
+        plugins={parent: SimpleNamespace(DATA_MODEL=FakeDataModel, ANALYZER_ARGS=FakeArgs)}
+    )
+
+    cfg = cli.generate_reference_config_from_logs(str(framework_fixtures_path), plugin_reg, logger)
+
+    assert isinstance(cfg, PluginConfig)
+    assert set(cfg.plugins) == {parent}
+    assert cfg.plugins[parent]["analysis_args"] == {}


### PR DESCRIPTION
Scope: Use previous node-scraper logs to generate a reference config by parsing the log files.
node-scraper --gen-reference-config-from-logs <path_to_previous_logs>

Sample run: 
```
node-scraper --gen-reference-config-from-logs scraper_logs_TheraC56_2025_07_07-11_11_08_AM/
```

Sample output:
```
$ node-scraper --gen-reference-config-from-logs scraper_logs_TheraC56_2025_07_07-11_11_08_AM/
  2025-07-07 14:13:41 CDT       INFO               nodescraper | Log path: ./scraper_logs_2025_07_07-02_13_41_PM
  2025-07-07 14:13:41 CDT       INFO               nodescraper | Reference config written to: /home/alexbara/node-scraper/reference_config.json
```
reference_config.json:
```
{
  "global_args": {},
  "plugins": {
    "BiosPlugin": {
      "analysis_args": {
        "exp_bios_version": [
          "M17"
        ],
        "regex_match": false
      }
    },
    "OsPlugin": {
      "analysis_args": {
        "exp_os": [
          "8.10"
        ],
        "exact_match": true
      }
    }
  },
  "result_collators": {}
```

README.md updates to follow