### PR TITLE
Added global args support in config

### DIFF
--- a/nodescraper/interfaces/dataplugin.py
+++ b/nodescraper/interfaces/dataplugin.py
@@ -38,7 +38,6 @@ from nodescraper.models import (
     SystemInfo,
     TaskResult,
 )
-from nodescraper.utils import normalize_enum
 
 from .connectionmanager import TConnectArg, TConnectionManager
 from .task import SystemCompatibilityError
@@ -163,10 +162,6 @@ class DataPlugin(
             return self.collection_result
 
         try:
-            max_event_priority_level = normalize_enum(max_event_priority_level, EventPriority)
-            system_interaction_level = normalize_enum(
-                system_interaction_level, SystemInteractionLevel
-            )
             if not self.connection_manager:
                 if not self.CONNECTION_TYPE:
                     self.collection_result = TaskResult(
@@ -247,8 +242,6 @@ class DataPlugin(
             TaskResult: result of data analysis
         """
 
-        max_event_priority_level = normalize_enum(max_event_priority_level, EventPriority)
-
         if self.ANALYZER is None:
             self.analysis_result = TaskResult(
                 status=ExecutionStatus.NOT_RAN,
@@ -306,8 +299,6 @@ class DataPlugin(
             PluginResult: Plugin result
         """
         self.logger.info("Running plugin %s", self.__class__.__name__)
-        max_event_priority_level = normalize_enum(max_event_priority_level, EventPriority)
-        system_interaction_level = normalize_enum(system_interaction_level, SystemInteractionLevel)
         if collection:
             self.collect(
                 max_event_priority_level=max_event_priority_level,

--- a/nodescraper/interfaces/dataplugin.py
+++ b/nodescraper/interfaces/dataplugin.py
@@ -38,6 +38,7 @@ from nodescraper.models import (
     SystemInfo,
     TaskResult,
 )
+from nodescraper.utils import normalize_enum
 
 from .connectionmanager import TConnectArg, TConnectionManager
 from .task import SystemCompatibilityError
@@ -162,6 +163,10 @@ class DataPlugin(
             return self.collection_result
 
         try:
+            max_event_priority_level = normalize_enum(max_event_priority_level, EventPriority)
+            system_interaction_level = normalize_enum(
+                system_interaction_level, SystemInteractionLevel
+            )
             if not self.connection_manager:
                 if not self.CONNECTION_TYPE:
                     self.collection_result = TaskResult(
@@ -241,6 +246,9 @@ class DataPlugin(
         Returns:
             TaskResult: result of data analysis
         """
+
+        max_event_priority_level = normalize_enum(max_event_priority_level, EventPriority)
+
         if self.ANALYZER is None:
             self.analysis_result = TaskResult(
                 status=ExecutionStatus.NOT_RAN,
@@ -298,6 +306,8 @@ class DataPlugin(
             PluginResult: Plugin result
         """
         self.logger.info("Running plugin %s", self.__class__.__name__)
+        max_event_priority_level = normalize_enum(max_event_priority_level, EventPriority)
+        system_interaction_level = normalize_enum(system_interaction_level, SystemInteractionLevel)
         if collection:
             self.collect(
                 max_event_priority_level=max_event_priority_level,

--- a/nodescraper/interfaces/task.py
+++ b/nodescraper/interfaces/task.py
@@ -80,6 +80,8 @@ class Task(abc.ABC):
     def max_event_priority_level(self, input_value: str | EventPriority):
         if isinstance(input_value, str):
             value: EventPriority = getattr(EventPriority, input_value)
+        elif isinstance(input_value, int):
+            value = EventPriority(input_value)
         elif isinstance(input_value, EventPriority):
             value: EventPriority = input_value
         else:

--- a/nodescraper/pluginexecutor.py
+++ b/nodescraper/pluginexecutor.py
@@ -165,14 +165,12 @@ class PluginExecutor:
                     plugin_inst = plugin_class(**init_payload)
 
                     run_payload = copy.deepcopy(plugin_args)
-
                     run_args = TypeUtils.get_func_arg_types(plugin_class.run, plugin_class)
 
                     for arg in run_args.keys():
                         if arg == "preserve_connection" and issubclass(plugin_class, DataPlugin):
                             run_payload[arg] = True
-                        elif arg in self.plugin_config.global_args:
-                            run_payload[arg] = self.plugin_config.global_args[arg]
+
                     try:
                         global_run_args = self.apply_global_args_to_plugin(
                             plugin_inst, plugin_class, self.plugin_config.global_args
@@ -239,17 +237,10 @@ class PluginExecutor:
         """
 
         run_args = {}
-        simple_keys = [
-            "collection",
-            "analysis",
-            "max_event_priority_level",
-            "system_interaction_level",
-            "preserve_connection",
-            "data",
-        ]
-
-        for key in simple_keys:
-            if key in global_args:
+        for key in global_args:
+            if key in ["collection_args", "analysis_args"] and isinstance(plugin_inst, DataPlugin):
+                continue
+            else:
                 run_args[key] = global_args[key]
 
         if "collection_args" in global_args and hasattr(plugin_class, "COLLECTOR_ARGS"):

--- a/nodescraper/pluginexecutor.py
+++ b/nodescraper/pluginexecutor.py
@@ -33,8 +33,6 @@ from typing import Optional, Type
 from pydantic import BaseModel
 
 from nodescraper.constants import DEFAULT_LOGGER
-from nodescraper.enums.eventpriority import EventPriority
-from nodescraper.enums.systeminteraction import SystemInteractionLevel
 from nodescraper.interfaces import ConnectionManager, DataPlugin, PluginInterface
 from nodescraper.models import PluginConfig, SystemInfo
 from nodescraper.models.pluginresult import PluginResult
@@ -170,20 +168,16 @@ class PluginExecutor:
 
                     run_args = TypeUtils.get_func_arg_types(plugin_class.run, plugin_class)
 
-                    enum_fields = {
-                        "max_event_priority_level": EventPriority,
-                        "system_interaction_level": SystemInteractionLevel,
-                    }
-
                     for arg in run_args.keys():
                         if arg == "preserve_connection" and issubclass(plugin_class, DataPlugin):
                             run_payload[arg] = True
                         elif arg in self.plugin_config.global_args:
                             run_payload[arg] = self.plugin_config.global_args[arg]
                     try:
-                        self.apply_global_args_to_plugin(
-                            plugin_inst, plugin_class, self.plugin_config.global_args, enum_fields
+                        global_run_args = self.apply_global_args_to_plugin(
+                            plugin_inst, plugin_class, self.plugin_config.global_args
                         )
+                        run_payload.update(global_run_args)
                     except ValueError as ve:
                         self.logger.error(
                             "Invalid global_args for plugin %s: %s. Skipping plugin.",
@@ -229,8 +223,11 @@ class PluginExecutor:
         return plugin_results
 
     def apply_global_args_to_plugin(
-        self, plugin_inst: PluginInterface, plugin_class: type, global_args: dict, enum_fields: dict
-    ) -> None:
+        self,
+        plugin_inst: PluginInterface,
+        plugin_class: type,
+        global_args: dict,
+    ) -> dict:
         """
         Applies global arguments to the plugin instance, including standard attributes
         and merging Pydantic model arguments (collection_args, analysis_args).
@@ -241,6 +238,7 @@ class PluginExecutor:
             global_args: Dict of global argument overrides.
         """
 
+        run_args = {}
         simple_keys = [
             "collection",
             "analysis",
@@ -252,43 +250,20 @@ class PluginExecutor:
 
         for key in simple_keys:
             if key in global_args:
-                value = global_args[key]
+                run_args[key] = global_args[key]
 
-                if key in enum_fields:
-                    enum_type = enum_fields[key]
-                    if isinstance(value, str):
-                        try:
-                            value = enum_type[value.upper()]
-                        except KeyError as kerr:
-                            raise ValueError(
-                                f"Invalid enum name '{value}' for {enum_type.__name__}"
-                            ) from kerr
-                    elif isinstance(value, int):
-                        try:
-                            value = enum_type(value)
-                        except ValueError as verr:
-                            raise ValueError(
-                                f"Invalid enum value '{value}' for {enum_type.__name__}"
-                            ) from verr
+        if "collection_args" in global_args and hasattr(plugin_class, "COLLECTOR_ARGS"):
+            plugin_fields = set(plugin_class.COLLECTOR_ARGS.__fields__.keys())
+            filtered = {
+                k: v for k, v in global_args["collection_args"].items() if k in plugin_fields
+            }
+            if filtered:
+                run_args["collection_args"] = filtered
 
-                setattr(plugin_inst, key, value)
+        if "analysis_args" in global_args and hasattr(plugin_class, "ANALYZER_ARGS"):
+            plugin_fields = set(plugin_class.ANALYZER_ARGS.__fields__.keys())
+            filtered = {k: v for k, v in global_args["analysis_args"].items() if k in plugin_fields}
+            if filtered:
+                run_args["analysis_args"] = filtered
 
-        if "collection_args" in global_args:
-            update_data = global_args["collection_args"]
-            existing = getattr(plugin_inst, "COLLECTION_ARGS", None)
-            model_class = getattr(plugin_class, "COLLECTOR_ARGS", None)
-
-            if isinstance(existing, BaseModel):
-                plugin_inst.COLLECTION_ARGS = existing.model_copy(update=update_data)
-            elif model_class and issubclass(model_class, BaseModel):
-                plugin_inst.COLLECTION_ARGS = model_class.model_validate(update_data)
-
-        if "analysis_args" in global_args:
-            update_data = global_args["analysis_args"]
-            existing = getattr(plugin_inst, "ANALYSIS_ARGS", None)
-            model_class = getattr(plugin_class, "ANALYZER_ARGS", None)
-
-            if isinstance(existing, BaseModel):
-                plugin_inst.ANALYSIS_ARGS = existing.model_copy(update=update_data)
-            elif model_class and issubclass(model_class, BaseModel):
-                plugin_inst.ANALYSIS_ARGS = model_class.model_validate(update_data)
+        return run_args

--- a/nodescraper/utils.py
+++ b/nodescraper/utils.py
@@ -169,13 +169,3 @@ def bytes_to_human_readable(input_bytes: int) -> str:
 
     gb = round(mb / 1000, 2)
     return f"{gb}GB"
-
-
-def normalize_enum(value, enum_type):
-    if isinstance(value, enum_type):
-        return value
-    elif isinstance(value, int):
-        return enum_type(value)
-    elif isinstance(value, str):
-        return enum_type[value.upper()]
-    raise ValueError(f"Invalid value '{value}' for enum {enum_type.__name__}")

--- a/nodescraper/utils.py
+++ b/nodescraper/utils.py
@@ -169,3 +169,13 @@ def bytes_to_human_readable(input_bytes: int) -> str:
 
     gb = round(mb / 1000, 2)
     return f"{gb}GB"
+
+
+def normalize_enum(value, enum_type):
+    if isinstance(value, enum_type):
+        return value
+    elif isinstance(value, int):
+        return enum_type(value)
+    elif isinstance(value, str):
+        return enum_type[value.upper()]
+    raise ValueError(f"Invalid value '{value}' for enum {enum_type.__name__}")

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -55,6 +55,7 @@ class DummyDataModel(DataModel):
 
 class DummyArg(BaseModel):
     value: int
+    regex_match: bool = True
 
 
 class DummyResult:


### PR DESCRIPTION
Global args in config will apply to plugins. Sample config with global args:
```
{
  "global_args": {
      "analysis_args": {
        "exp_bios_version": [
          "M17"
        ],
        "regex_match": false
      },
      "max_event_priority_level" : 1,
      "system_interaction_level" : "INTERACTIVE",
      "preserve_connection" : 1,
      "collection" : 1,
      "analysis" : 0
  },
  "plugins": {
    "BiosPlugin": {
    }
  },
  "result_collators": {}
}
```
Sample run for this config:
```
node-scraper --plugin-configs reference_config_globals.py
```
For the above, analysis will not run, collection only. analysis_args will try and be applied to plugins where those args are supported when analysis is enabled.