### PR TITLE
Fix for generating reference config

### DIFF
--- a/nodescraper/plugins/inband/os/analyzer_args.py
+++ b/nodescraper/plugins/inband/os/analyzer_args.py
@@ -59,4 +59,4 @@ class OsAnalyzerArgs(AnalyzerArgs):
         Returns:
             OsAnalyzerArgs: instance of analyzer args class
         """
-        return cls(exp_os=datamodel.os_version)
+        return cls(exp_os=datamodel.os_name)

--- a/nodescraper/plugins/inband/package/analyzer_args.py
+++ b/nodescraper/plugins/inband/package/analyzer_args.py
@@ -31,7 +31,7 @@ from nodescraper.plugins.inband.package.packagedata import PackageDataModel
 
 class PackageAnalyzerArgs(AnalyzerArgs):
     exp_package_ver: dict[str, str | None] = Field(default_factory=dict)
-    regex_match: bool = True
+    regex_match: bool = False
 
     @classmethod
     def build_from_model(cls, datamodel: PackageDataModel) -> "PackageAnalyzerArgs":


### PR DESCRIPTION
Fixes the workflow: 
```
node-scraper --gen-reference-config run-plugins PackagePlugin OsPlugin
node-scraper --plugin-configs reference_config.json
```

The data dumped in reference_config.json is then used correctly in --plugin-config.
Without this fix OsPlugin and PackagePlugin fail the analysis part with --plugin-config. 