### PR TITLE
global_args: preserve_connection fix

### DIFF
--- a/nodescraper/interfaces/connectionmanager.py
+++ b/nodescraper/interfaces/connectionmanager.py
@@ -140,3 +140,4 @@ class ConnectionManager(Task, Generic[TConnection, TConnectArg]):
     def disconnect(self):
         """disconnect connection (Optional)"""
         self.connection = None
+        self.result.status = ExecutionStatus.UNSET


### PR DESCRIPTION
Before fix:
```

(venv) (base) [alexbara@TheraC60 node-scraper]$  node-scraper --plugin-config reference_config_globals2.py
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Log path: ./scraper_logs_therac60_2025_07_31-09_29_07_AM
  2025-07-31 09:29:07 CDT       INFO               nodescraper | System Name: TheraC60
  2025-07-31 09:29:07 CDT       INFO               nodescraper | System SKU: None
  2025-07-31 09:29:07 CDT       INFO               nodescraper | System Platform: None
  2025-07-31 09:29:07 CDT       INFO               nodescraper | System location: SystemLocation.LOCAL
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2025-07-31 09:29:07 CDT       INFO               nodescraper | --------------------------------------------------
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running plugin DimmPlugin
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Using local shell
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Checking OS family
  2025-07-31 09:29:07 CDT       INFO               nodescraper | OS Family: LINUX
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running data collector: DimmCollector
  2025-07-31 09:29:07 CDT       INFO               nodescraper | (DimmPlugin) DIMM: 2048GB @ 16 x 128GB
  2025-07-31 09:29:07 CDT       INFO               nodescraper | --------------------------------------------------
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running plugin StoragePlugin
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running data collector: StorageCollector
  2025-07-31 09:29:07 CDT   CRITICAL               nodescraper | Exception: 'NoneType' object has no attribute 'run_command'
  2025-07-31 09:29:07 CDT   CRITICAL               nodescraper | (StoragePlugin) task failed to run
  2025-07-31 09:29:07 CDT       INFO               nodescraper | --------------------------------------------------
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running plugin DmesgPlugin
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running data collector: DmesgCollector
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running dmesg command on system
  2025-07-31 09:29:07 CDT   CRITICAL               nodescraper | Exception: 'NoneType' object has no attribute 'run_command'
  2025-07-31 09:29:07 CDT   CRITICAL               nodescraper | (DmesgPlugin) task failed to run
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Closing connections
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running result collators
  2025-07-31 09:29:07 CDT       INFO               nodescraper | Running TableSummary result collator
  2025-07-31 09:29:07 CDT       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
|  Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
|  InBandConnectionManager | OK     | task completed successfully |
+-------------------------+--------+-----------------------------+

+---------------+-------------------+--------------------------------------+
|  Plugin        | Status            | Message                              |
+---------------+-------------------+--------------------------------------+
|  DimmPlugin    | OK                | Plugin tasks completed successfully  |
|  StoragePlugin | EXECUTION_FAILURE | Collection error: task failed to run |
|  DmesgPlugin   | EXECUTION_FAILURE | Collection error: task failed to run |
+---------------+-------------------+--------------------------------------+

  2025-07-31 09:29:07 CDT       INFO               nodescraper | Data written to csv file: ./scraper_logs_therac60_2025_07_31-09_29_07_AM/nodescraper.csv

```
Config file:
```
(venv) (base) [alexbara@TheraC60 node-scraper]$ cat reference_config_globals2.py
{
  "global_args": {
      "analysis_args": {
        "exp_bios_version": [
          "M17"
        ],
        "regex_match": false
      },
      "collection_args": {
        "skip_sudo" : 0
      },
      "max_event_priority_level" : 1,
      "system_interaction_level" : 1,
      "preserve_connection" : 0,
      "collection" : 1,
      "analysis" : 0
  },
  "plugins": {
    "DimmPlugin": {},
    "StoragePlugin": {},
    "DmesgPlugin": {}
  },
  "result_collators": {}
}

```

After fix:
```
=
(venv) (base) [alexbara@TheraC60 node-scraper]$  node-scraper --plugin-config reference_config_globals2.py
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Log path: ./scraper_logs_therac60_2025_07_31-09_39_31_AM
  2025-07-31 09:39:31 CDT       INFO               nodescraper | System Name: TheraC60
  2025-07-31 09:39:31 CDT       INFO               nodescraper | System SKU: None
  2025-07-31 09:39:31 CDT       INFO               nodescraper | System Platform: None
  2025-07-31 09:39:31 CDT       INFO               nodescraper | System location: SystemLocation.LOCAL
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2025-07-31 09:39:31 CDT       INFO               nodescraper | --------------------------------------------------
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running plugin DimmPlugin
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Using local shell
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Checking OS family
  2025-07-31 09:39:31 CDT       INFO               nodescraper | OS Family: LINUX
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running data collector: DimmCollector
  2025-07-31 09:39:31 CDT       INFO               nodescraper | (DimmPlugin) DIMM: 2048GB @ 16 x 128GB
  2025-07-31 09:39:31 CDT       INFO               nodescraper | --------------------------------------------------
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running plugin StoragePlugin
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running data collector: StorageCollector
  2025-07-31 09:39:31 CDT       INFO               nodescraper | (StoragePlugin) 3 storage devices collected
  2025-07-31 09:39:31 CDT       INFO               nodescraper | --------------------------------------------------
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running plugin DmesgPlugin
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running data collector: DmesgCollector
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running dmesg command on system
  2025-07-31 09:39:31 CDT       INFO               nodescraper | (DmesgPlugin) Dmesg data collected
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Closing connections
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running result collators
  2025-07-31 09:39:31 CDT       INFO               nodescraper | Running TableSummary result collator
  2025-07-31 09:39:31 CDT       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
|  Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
|  InBandConnectionManager | UNSET  | task completed successfully |
+-------------------------+--------+-----------------------------+

+---------------+--------+-------------------------------------+
|  Plugin        | Status | Message                             |
+---------------+--------+-------------------------------------+
|  DimmPlugin    | OK     | Plugin tasks completed successfully |
|  StoragePlugin | OK     | Plugin tasks completed successfully |
|  DmesgPlugin   | OK     | Plugin tasks completed successfully |
+---------------+--------+-------------------------------------+

  2025-07-31 09:39:31 CDT       INFO               nodesc
```