### PR TITLE
Allowing reference config to use log_path when provided

### DIFF
--- a/nodescraper/cli/cli.py
+++ b/nodescraper/cli/cli.py
@@ -437,7 +437,10 @@ def main(arg_input: Optional[list[str]] = None):
 
         if parsed_args.reference_config:
             ref_config = generate_reference_config(results, plugin_reg, logger)
-            path = os.path.join(os.getcwd(), "reference_config.json")
+            if log_path:
+                path = os.path.join(log_path, "reference_config.json")
+            else:
+                path = os.path.join(os.getcwd(), "reference_config.json")
             try:
                 with open(path, "w") as f:
                     json.dump(


### PR DESCRIPTION
This enables to run through srun and provide custom path for reference_config.json
```
srun -N 2 -n 2 --ntasks-per-node=1 -p MI250 bash -c 'source /home/alexbara/node-scraper/venv/bin/activate ; node-scraper --gen-reference-config  --log-path /mnt/thera/data/incoming/node-scraper/ run-plugins BiosPlugin'
```