### PR TITLE
Rocm plugin update: updated regex for rocm version to accept 7.0.0

### DIFF
--- a/nodescraper/plugins/inband/rocm/rocmdata.py
+++ b/nodescraper/plugins/inband/rocm/rocmdata.py
@@ -48,12 +48,6 @@ class RocmDataModel(DataModel):
         Returns:
             str: The validated ROCm version string.
         """
-        if not bool(
-            re.match(
-                r"^(\d+(?:\.\d+){0,3})-(\d+)$",
-                rocm_version,
-            )
-        ):
+        if not re.match(r"^\d+(?:\.\d+){0,3}(-\d+)?$", rocm_version):
             raise ValueError(f"ROCm version has invalid format: {rocm_version}")
-
         return rocm_version


### PR DESCRIPTION
Previous behavior: 
```
(venv) root@TheraC61:/mnt/kgr/node-scraper/node-scraper# node-scraper run-plugins RocmPlugin
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Log path: ./scraper_logs_therac61_2025_08_06-07_37_37_PM
  2025-08-06 19:37:37 UTC       INFO               nodescraper | System Name: TheraC61
  2025-08-06 19:37:37 UTC       INFO               nodescraper | System SKU: None
  2025-08-06 19:37:37 UTC       INFO               nodescraper | System Platform: None
  2025-08-06 19:37:37 UTC       INFO               nodescraper | System location: SystemLocation.LOCAL
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2025-08-06 19:37:37 UTC       INFO               nodescraper | --------------------------------------------------
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Running plugin RocmPlugin
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Using local shell
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Checking OS family
  2025-08-06 19:37:37 UTC       INFO               nodescraper | OS Family: LINUX
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Running data collector: RocmCollector
  2025-08-06 19:37:37 UTC   CRITICAL               nodescraper | Pydantic validation error
  2025-08-06 19:37:37 UTC   CRITICAL               nodescraper | (RocmPlugin) task failed to run (1 errors)
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Closing connections
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Running result collators
  2025-08-06 19:37:37 UTC       INFO               nodescraper | Running TableSummary result collator
  2025-08-06 19:37:37 UTC       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
|  Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
|  InBandConnectionManager | UNSET  | task completed successfully |
+-------------------------+--------+-----------------------------+

+------------+-------------------+----------------------------------------------------------------------------------------------------------------------+
|  Plugin     | Status            | Message                                                                                                              |
+------------+-------------------+----------------------------------------------------------------------------------------------------------------------+
|  RocmPlugin | EXECUTION_FAILURE | Collection error: Unhandled exception running data collector: Unable to serialize unknown type: <class 'ValueError'> |
+------------+-------------------+----------------------------------------------------------------------------------------------------------------------+

```

Current behavior:
```
(venv) root@TheraC61:/mnt/kgr/node-scraper/node-scraper# node-scraper run-plugins RocmPlugin
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Log path: ./scraper_logs_therac61_2025_08_06-07_46_05_PM
  2025-08-06 19:46:05 UTC       INFO               nodescraper | System Name: TheraC61
  2025-08-06 19:46:05 UTC       INFO               nodescraper | System SKU: None
  2025-08-06 19:46:05 UTC       INFO               nodescraper | System Platform: None
  2025-08-06 19:46:05 UTC       INFO               nodescraper | System location: SystemLocation.LOCAL
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2025-08-06 19:46:05 UTC       INFO               nodescraper | --------------------------------------------------
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Running plugin RocmPlugin
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Using local shell
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Checking OS family
  2025-08-06 19:46:05 UTC       INFO               nodescraper | OS Family: LINUX
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Running data collector: RocmCollector
STDOUT: %s 7.0.0
  2025-08-06 19:46:05 UTC       INFO               nodescraper | (RocmPlugin) ROCm: {'rocm_version': '7.0.0'}
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Running data analyzer: RocmAnalyzer
  2025-08-06 19:46:05 UTC       INFO               nodescraper | (RocmPlugin) Expected ROCm not provided
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Closing connections
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Running result collators
  2025-08-06 19:46:05 UTC       INFO               nodescraper | Running TableSummary result collator
  2025-08-06 19:46:05 UTC       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
|  Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
|  InBandConnectionManager | UNSET  | task completed successfully |
+-------------------------+--------+-----------------------------+

+------------+--------+-------------------------------------+
|  Plugin     | Status | Message                             |
+------------+--------+-------------------------------------+
|  RocmPlugin | OK     | Plugin tasks completed successfully |
+------------+--------+-------------------------------------+

  2025-08-06 19:46:05 UTC       INFO               nodescraper | Data written to csv file: ./scraper_logs_therac61_2025_08_06-07_46_05_PM/nodescraper.csv

```