### PR TITLE
Changing node-scraper to use venv rather than virtualenv

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,7 +1,7 @@
 # Create venv if not already present
 if [ ! -d "venv" ]; then
-    python3 -m pip install virtualenv
-    python3 -m virtualenv venv
+    python3 -m pip install venv
+    python3 -m venv venv
 fi
 
 # Activate the desired venv


### PR DESCRIPTION
python venv is part of python now and most of the features, some versions of linux have integrated pip into their package management software, including debian which ubuntu 24 is built on.  venv built into python covers the standard uses cases for this projects needs. 
When running inside the standard Ubuntu 24.04 container (without any tweekts to python other than full install) I recieved the following error:

```
 Running dev-setup.sh in /mnt/kgr/build/node-scraper/node-scraper
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
When using venv, there is no error, and the venv can be setup as expected. 