### PR TITLE
Dmesg analyzer update

### DIFF
--- a/nodescraper/models/event.py
+++ b/nodescraper/models/event.py
@@ -50,7 +50,7 @@ class Event(BaseModel):
     timestamp: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
     )
-    reporter: str = "ERROR_SCRAPER"
+    reporter: str = "NODE_SCRAPER"
     category: str
     description: str
     data: dict = Field(default_factory=dict)

--- a/nodescraper/plugins/inband/dmesg/dmesg_analyzer.py
+++ b/nodescraper/plugins/inband/dmesg/dmesg_analyzer.py
@@ -53,7 +53,7 @@ class DmesgAnalyzer(RegexAnalyzer[DmesgData, DmesgAnalyzerArgs]):
             event_category=EventCategory.SW_DRIVER,
         ),
         ErrorRegex(
-            regex=re.compile(r"[Kk]ernel panic.*"),
+            regex=re.compile(r"\bkernel panic\b.*", re.IGNORECASE),
             message="Kernel Panic",
             event_category=EventCategory.SW_DRIVER,
         ),
@@ -292,6 +292,33 @@ class DmesgAnalyzer(RegexAnalyzer[DmesgData, DmesgAnalyzerArgs]):
             regex=re.compile(r"amdgpu \w{4}:\w{2}:\w{2}.\w: amdgpu: WARN: GPU is throttled.*"),
             message="GPU Throttled",
             event_category=EventCategory.SW_DRIVER,
+            event_priority=EventPriority.WARNING,
+        ),
+        ErrorRegex(
+            regex=re.compile(
+                r"(?:\[[^\]]+\]\s*)?LNetError:.*ko2iblnd:\s*No matching interfaces",
+                re.IGNORECASE,
+            ),
+            message="LNet: ko2iblnd has no matching interfaces",
+            event_category=EventCategory.IO,
+            event_priority=EventPriority.WARNING,
+        ),
+        ErrorRegex(
+            regex=re.compile(
+                r"(?:\[[^\]]+\]\s*)?LNetError:\s*.*Error\s*-?\d+\s+starting up LNI\s+\w+",
+                re.IGNORECASE,
+            ),
+            message="LNet: Error starting up LNI",
+            event_category=EventCategory.IO,
+            event_priority=EventPriority.WARNING,
+        ),
+        ErrorRegex(
+            regex=re.compile(
+                r"LustreError:.*ptlrpc_init_portals\(\).*network initiali[sz]ation failed",
+                re.IGNORECASE,
+            ),
+            message="Lustre: network initialisation failed",
+            event_category=EventCategory.IO,
             event_priority=EventPriority.WARNING,
         ),
     ]


### PR DESCRIPTION
Catching 3 more regexes
```
"[  548.063411] LNetError: 2719:0:(o2iblnd.c:3327:kiblnd_startup()) ko2iblnd: No matching interfaces",
            "[  548.073737] LNetError: 105-4: Error -100 starting up LNI o2ib",
            "[Wed Jun 25 17:19:52 2025] LustreError: 2719:0:(events.c:639:ptlrpc_init_portals()) network initialisation failed",
```

@hearnsj-amd  anything in here ^ that needs to be abstracted please let me know.