### PR TITLE
Dmesg log collection

### DIFF
--- a/nodescraper/plugins/inband/dmesg/collector_args.py
+++ b/nodescraper/plugins/inband/dmesg/collector_args.py
@@ -23,24 +23,9 @@
 # SOFTWARE.
 #
 ###############################################################################
-from nodescraper.base import InBandDataPlugin
 
-from .analyzer_args import DmesgAnalyzerArgs
-from .collector_args import DmesgCollectorArgs
-from .dmesg_analyzer import DmesgAnalyzer
-from .dmesg_collector import DmesgCollector
-from .dmesgdata import DmesgData
+from nodescraper.models import CollectorArgs
 
 
-class DmesgPlugin(InBandDataPlugin[DmesgData, DmesgCollectorArgs, DmesgAnalyzerArgs]):
-    """Plugin for collection and analysis of dmesg data"""
-
-    DATA_MODEL = DmesgData
-
-    COLLECTOR = DmesgCollector
-
-    ANALYZER = DmesgAnalyzer
-
-    ANALYZER_ARGS = DmesgAnalyzerArgs
-
-    COLLECTOR_ARGS = DmesgCollectorArgs
+class DmesgCollectorArgs(CollectorArgs):
+    collect_logs: bool = False

--- a/nodescraper/plugins/inband/dmesg/dmesg_collector.py
+++ b/nodescraper/plugins/inband/dmesg/dmesg_collector.py
@@ -23,7 +23,10 @@
 # SOFTWARE.
 #
 ###############################################################################
+import re
+
 from nodescraper.base import InBandDataCollector
+from nodescraper.connection.inband import FileArtifact
 from nodescraper.enums import EventCategory, EventPriority, OSFamily
 from nodescraper.models import TaskResult
 
@@ -38,6 +41,84 @@ class DmesgCollector(InBandDataCollector[DmesgData, None]):
     DATA_MODEL = DmesgData
 
     DMESG_CMD = "dmesg --time-format iso -x"
+
+    DMESG_LIST_CMD = (
+        r"ls -1 /var/log/dmesg /var/log/dmesg.1 /var/log/dmesg.[0-9]*.gz 2>/dev/null || true"
+    )
+
+    def _shell_quote(self, s: str) -> str:
+        """POSIX single-quote."""
+        return "'" + s.replace("'", "'\"'\"'") + "'"
+
+    def _nice_dmesg_name(self, path: str) -> str:
+        """Map path to filename"""
+        if path.endswith("/dmesg"):
+            return "dmesg.log"
+        if path.endswith("/dmesg.1"):
+            return "dmesg.1.log"
+        m = re.search(r"/dmesg\.(\d+)\.gz$", path)
+        if m:
+            return f"dmesg.{m.group(1)}.log"
+        base = path.rsplit("/", 1)[-1]
+        return base.replace(".gz", "") + ".log"
+
+    def _collect_dmesg_rotations(self) -> int:
+        """
+        Collect /var/log/dmesg, /var/log/dmesg.1, and /var/log/dmesg.N.gz (decompressed).
+        Attaches each as a text artifact.
+
+        Returns:
+             list: list of logs collected.
+
+        """
+        list_res = self._run_sut_cmd(self.DMESG_LIST_CMD)
+        paths = [p.strip() for p in (list_res.stdout or "").splitlines() if p.strip()]
+        if not paths:
+            self._log_event(
+                category=EventCategory.OS,
+                description="No /var/log/dmesg files found (including rotations).",
+                data={"list_exit_code": list_res.exit_code},
+                priority=EventPriority.WARNING,
+            )
+            return 0
+
+        collected, failed = [], []
+        for p in paths:
+            qp = self._shell_quote(p)
+            if p.endswith(".gz"):
+                cmd = f"(command -v gzip >/dev/null && gzip -dc {qp}) || (command -v zcat >/dev/null && zcat {qp}) || cat {qp}"
+            else:
+                cmd = f"cat {qp}"
+
+            res = self._run_sut_cmd(cmd)
+            if res.exit_code == 0 and res.stdout is not None:
+                fname = self._nice_dmesg_name(p)
+                self.result.artifacts.append(FileArtifact(filename=fname, contents=res.stdout))
+                collected.append(
+                    {"path": p, "as": fname, "bytes": len(res.stdout.encode("utf-8", "ignore"))}
+                )
+            else:
+                failed.append({"path": p, "exit_code": res.exit_code, "stderr": res.stderr})
+
+        if collected:
+            self._log_event(
+                category=EventCategory.OS,
+                description="Collected dmesg rotated files",
+                data={"collected": collected},
+                priority=EventPriority.INFO,
+            )
+            # self.result.status = self.result.status or ExecutionStatus.OK
+            self.result.message = self.result.message or "dmesg rotated files collected"
+
+        if failed:
+            self._log_event(
+                category=EventCategory.OS,
+                description="Some dmesg files could not be collected.",
+                data={"failed": failed},
+                priority=EventPriority.WARNING,
+            )
+
+        return collected
 
     def _get_dmesg_content(self) -> str:
         """run dmesg command on system and return output
@@ -68,6 +149,7 @@ class DmesgCollector(InBandDataCollector[DmesgData, None]):
             tuple[TaskResult, DmesgData | None]: tuple containing the result of the task and the dmesg data if available
         """
         dmesg_content = self._get_dmesg_content()
+        _ = self._collect_dmesg_rotations()
 
         if dmesg_content:
             dmesg_data = DmesgData(dmesg_content=dmesg_content)

--- a/nodescraper/plugins/inband/dmesg/dmesg_plugin.py
+++ b/nodescraper/plugins/inband/dmesg/dmesg_plugin.py
@@ -41,6 +41,4 @@ class DmesgPlugin(InBandDataPlugin[DmesgData, DmesgCollectorArgs, DmesgAnalyzerA
 
     ANALYZER = DmesgAnalyzer
 
-    ANALYZER_ARGS = DmesgAnalyzerArgs
-
     COLLECTOR_ARGS = DmesgCollectorArgs

--- a/nodescraper/plugins/inband/dmesg/dmesgdata.py
+++ b/nodescraper/plugins/inband/dmesg/dmesgdata.py
@@ -34,6 +34,7 @@ class DmesgData(DataModel):
     """Data model for in band dmesg log"""
 
     dmesg_content: str
+    dmesg_logs: list[dict] = None
 
     @classmethod
     def get_new_dmesg_lines(cls, current_dmesg: str, new_dmesg: str) -> str:

--- a/test/unit/plugin/test_dmesg_collector.py
+++ b/test/unit/plugin/test_dmesg_collector.py
@@ -159,7 +159,7 @@ def get_collector(monkeypatch, run_map, system_info, conn_mock):
         system_interaction_level=SystemInteractionLevel.INTERACTIVE,
         connection=conn_mock,
     )
-    c.result = types.SimpleNamespace(artifacts=[], message=None)  # minimal fields we use
+    c.result = types.SimpleNamespace(artifacts=[], message=None)
     c._events = []
 
     def _log_event(**kw):


### PR DESCRIPTION
Sample run:
```
 node-scraper  run-plugins DmesgPlugin --collect-logs=True
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Log path: ./scraper_logs_pp_128_a5_1_2025_08_14-01_03_48_PM
  2025-08-14 13:03:48 CDT       INFO               nodescraper | System Name: <>
  2025-08-14 13:03:48 CDT       INFO               nodescraper | System SKU: None
  2025-08-14 13:03:48 CDT       INFO               nodescraper | System Platform: None
  2025-08-14 13:03:48 CDT       INFO               nodescraper | System location: SystemLocation.LOCAL
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2025-08-14 13:03:48 CDT       INFO               nodescraper | --------------------------------------------------
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Running plugin DmesgPlugin
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Using local shell
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Checking OS family
  2025-08-14 13:03:48 CDT       INFO               nodescraper | OS Family: LINUX
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Running data collector: DmesgCollector
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Running dmesg command on system
  2025-08-14 13:03:48 CDT       INFO               nodescraper | Collected dmesg log: dmesg_log.log
  2025-08-14 13:03:49 CDT       INFO               nodescraper | Collected dmesg log: dmesg.0.log
  2025-08-14 13:03:49 CDT       INFO               nodescraper | Collected dmesg log: dmesg.1.gz.log
  2025-08-14 13:03:49 CDT       INFO               nodescraper | Collected dmesg log: dmesg.2.gz.log
  2025-08-14 13:03:49 CDT       INFO               nodescraper | Collected dmesg log: dmesg.3.gz.log
  2025-08-14 13:03:49 CDT       INFO               nodescraper | Collected dmesg log: dmesg.4.gz.log
  2025-08-14 13:03:49 CDT       INFO               nodescraper | (DmesgPlugin) Dmesg data collected
  2025-08-14 13:03:49 CDT       INFO               nodescraper | Running data analyzer: DmesgAnalyzer
  2025-08-14 13:03:50 CDT      ERROR               nodescraper | (DmesgPlugin) task detected errors (2 warnings|10 errors)
  2025-08-14 13:03:50 CDT       INFO               nodescraper | Closing connections
  2025-08-14 13:03:50 CDT       INFO               nodescraper | Running result collators
  2025-08-14 13:03:50 CDT       INFO               nodescraper | Running TableSummary result collator
  2025-08-14 13:03:50 CDT       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
|  Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
|  InBandConnectionManager | UNSET  | task completed successfully |
+-------------------------+--------+-----------------------------+

+-------------+--------+-------------------------------------------------------------+
|  Plugin      | Status | Message                                                     |
+-------------+--------+-------------------------------------------------------------+
|  DmesgPlugin | ERROR  | Analysis error: task detected errors (2 warnings|10 errors) |
+-------------+--------+-------------------------------------------------------------+

  2025-08-14 13:03:50 CDT       INFO               nodescraper | Data written to csv file: ./scraper_logs_pp_128_a5_1_2025_08_14-01_03_48_PM/nodescraper.csv

```

Dmesg logs collected are written to the log folder:
```
ls ./scraper_logs_pp_128_a5_1_2025_08_14-01_03_48_PM/dmesg_plugin/dmesg_collector/
command_artifacts.json  dmesg.0.log  dmesg.1.gz.log  dmesg.2.gz.log  dmesg.3.gz.log  dmesg.4.gz.log  dmesg.log  dmesg_log.log  events.json  result.json
```
