### PR TITLE
Bugfix: fix for status on InbandConnection

### DIFF
--- a/nodescraper/pluginexecutor.py
+++ b/nodescraper/pluginexecutor.py
@@ -194,8 +194,6 @@ class PluginExecutor:
             self.logger.exception("Unexpected exception running plugin queue: %s", str(e))
         finally:
             self.logger.info("Closing connections")
-            for connection_manager in self.connection_library.values():
-                connection_manager.disconnect()
 
             if self.plugin_config.result_collators:
                 self.logger.info("Running result collators")
@@ -217,6 +215,8 @@ class PluginExecutor:
                         ],
                         **collator_args,
                     )
+            for connection_manager in self.connection_library.values():
+                connection_manager.disconnect()
 
         return plugin_results
 


### PR DESCRIPTION
Moved the disconnect call after result collation to maintain status of connection in printouts.
Notice `InBandConnectionManager ` went from UNSET -> OK
Before:
```
(venv) (base) [alexbara@TheraC56 node-scraper]$ node-scraper run-plugins OsPlugin
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Log path: ./scraper_logs_therac56_2025_08_19-09_17_43_AM
  2025-08-19 09:17:43 CDT       INFO               nodescraper | System Name: TheraC56
  2025-08-19 09:17:43 CDT       INFO               nodescraper | System SKU: None
  2025-08-19 09:17:43 CDT       INFO               nodescraper | System Platform: None
  2025-08-19 09:17:43 CDT       INFO               nodescraper | System location: SystemLocation.LOCAL
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2025-08-19 09:17:43 CDT       INFO               nodescraper | --------------------------------------------------
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Running plugin OsPlugin
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Using local shell
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Checking OS family
  2025-08-19 09:17:43 CDT       INFO               nodescraper | OS Family: LINUX
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Running data collector: OsCollector
  2025-08-19 09:17:43 CDT       INFO               nodescraper | (OsPlugin) OS: Red Hat Enterprise Linux 8.10 (Ootpa)
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Running data analyzer: OsAnalyzer
  2025-08-19 09:17:43 CDT       INFO               nodescraper | (OsPlugin) Expected OS name not provided
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Closing connections
disconecting
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Running result collators
  2025-08-19 09:17:43 CDT       INFO               nodescraper | Running TableSummary result collator
  2025-08-19 09:17:43 CDT       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
|  Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
|  InBandConnectionManager | UNSET  | task completed successfully |
+-------------------------+--------+-----------------------------+

+----------+--------+-------------------------------------+
|  Plugin   | Status | Message                             |
+----------+--------+-------------------------------------+
|  OsPlugin | OK     | Plugin tasks completed successfully |
+----------+--------+-------------------------------------+

```

After:
```
(venv) (base) [alexbara@TheraC56 node-scraper]$ node-scraper run-plugins OsPlugin
  2025-08-19 10:25:30 CDT       INFO               nodescraper | Log path: ./scraper_logs_therac56_2025_08_19-10_25_30_AM
  2025-08-19 10:25:31 CDT       INFO               nodescraper | System Name: TheraC56
  2025-08-19 10:25:31 CDT       INFO               nodescraper | System SKU: None
  2025-08-19 10:25:31 CDT       INFO               nodescraper | System Platform: None
  2025-08-19 10:25:31 CDT       INFO               nodescraper | System location: SystemLocation.LOCAL
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2025-08-19 10:25:31 CDT       INFO               nodescraper | --------------------------------------------------
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Running plugin OsPlugin
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Using local shell
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Checking OS family
  2025-08-19 10:25:31 CDT       INFO               nodescraper | OS Family: LINUX
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Running data collector: OsCollector
  2025-08-19 10:25:31 CDT       INFO               nodescraper | (OsPlugin) OS: Red Hat Enterprise Linux 8.10 (Ootpa)
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Running data analyzer: OsAnalyzer
  2025-08-19 10:25:31 CDT       INFO               nodescraper | (OsPlugin) Expected OS name not provided
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Closing connections
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Running result collators
  2025-08-19 10:25:31 CDT       INFO               nodescraper | Running TableSummary result collator
  2025-08-19 10:25:31 CDT       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
|  Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
|  InBandConnectionManager | OK     | task completed successfully |
+-------------------------+--------+-----------------------------+

+----------+--------+-------------------------------------+
|  Plugin   | Status | Message                             |
+----------+--------+-------------------------------------+
|  OsPlugin | OK     | Plugin tasks completed successfully |
+----------+--------+-------------------------------------+

  2025-08-19 10:25:31 CDT       INFO               nodescraper | Data written to csv file: ./scraper_logs_therac56_2025_08_19-10_25_30_AM/nodescraper.csv

```