### PR TITLE
MemoryPlugin printout update

### DIFF
--- a/nodescraper/plugins/inband/memory/memory_analyzer.py
+++ b/nodescraper/plugins/inband/memory/memory_analyzer.py
@@ -91,7 +91,7 @@ class MemoryAnalyzer(DataAnalyzer[MemoryDataModel, MemoryAnalyzerArgs]):
             self.result.status = ExecutionStatus.ERROR
             self._log_event(
                 category=EventCategory.OS,
-                description=(f"{self.result.message}"),
+                description=self.result.message,
                 priority=EventPriority.CRITICAL,
             )
 


### PR DESCRIPTION
To run:
```
node-scraper run-plugins MemoryPlugin
```

Fixed mem printout for clarity. Turned into GB + added if ratio or max was used.  New print:
```
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Running plugin MemoryPlugin
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Using local shell
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Checking OS family
  2025-10-01 13:41:15 CDT       INFO               nodescraper | OS Family: LINUX
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Running data collector: MemoryCollector
  2025-10-01 13:41:15 CDT       INFO               nodescraper | (MemoryPlugin) Memory: {'mem_free': '1994577997824', 'mem_total': '2164310941696'}
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Running data analyzer: MemoryAnalyzer
  2025-10-01 13:41:15 CDT      ERROR               nodescraper | (MemoryPlugin) Memory usage exceeded max allowed! Used 158.08 GB, max allowed 19.80 GB (base=memory_threshold (max_expected) 30.00 GB × ratio=0.66) (1 errors)
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Closing connections
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Running result collators
  2025-10-01 13:41:15 CDT       INFO               nodescraper | Running TableSummary result collator
  2025-10-01 13:41:15 CDT       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
| Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
| InBandConnectionManager | OK     | task completed successfully |
+-------------------------+--------+-----------------------------+

+--------------+--------+----------------------------------------------------------------------------------+
| Plugin       | Status | Message                                                                          |
+--------------+--------+----------------------------------------------------------------------------------+
| MemoryPlugin | ERROR  | Analysis error: Memory usage exceeded max allowed! Used 158.08 GB, max allowed   |
|              |        | 19.80 GB (base=memory_threshold (max_expected) 30.00 GB × ratio=0.66) (1 errors) |
+--------------+--------+----------------------------------------------------------------------------------+

```