### PR TITLE
AmdSmiPlugin update: cper AFID val

### DIFF
--- a/nodescraper/plugins/inband/amdsmi/amdsmidata.py
+++ b/nodescraper/plugins/inband/amdsmi/amdsmidata.py
@@ -954,6 +954,7 @@ class AmdSmiDataModel(DataModel):
     xgmi_metric: Optional[list[XgmiMetrics]] = Field(default_factory=list)
     xgmi_link: Optional[list[XgmiLinks]] = Field(default_factory=list)
     cper_data: Optional[list[FileModel]] = Field(default_factory=list)
+    cper_afid: Optional[int] = None
     amdsmitst_data: AmdSmiTstData = Field(default_factory=AmdSmiTstData)
 
     def get_list(self, gpu: int) -> Optional[AmdSmiListItem]:

--- a/nodescraper/plugins/inband/amdsmi/amdsmidata.py
+++ b/nodescraper/plugins/inband/amdsmi/amdsmidata.py
@@ -954,7 +954,7 @@ class AmdSmiDataModel(DataModel):
     xgmi_metric: Optional[list[XgmiMetrics]] = Field(default_factory=list)
     xgmi_link: Optional[list[XgmiLinks]] = Field(default_factory=list)
     cper_data: Optional[list[FileModel]] = Field(default_factory=list)
-    cper_afid: Optional[int] = None
+    cper_afids: dict[str, int] = Field(default_factory=dict)
     amdsmitst_data: AmdSmiTstData = Field(default_factory=AmdSmiTstData)
 
     def get_list(self, gpu: int) -> Optional[AmdSmiListItem]:

--- a/nodescraper/plugins/inband/amdsmi/collector_args.py
+++ b/nodescraper/plugins/inband/amdsmi/collector_args.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,24 +23,12 @@
 # SOFTWARE.
 #
 ###############################################################################
-from nodescraper.base import InBandDataPlugin
+from typing import Optional
 
-from .amdsmi_analyzer import AmdSmiAnalyzer
-from .amdsmi_collector import AmdSmiCollector
-from .amdsmidata import AmdSmiDataModel
-from .analyzer_args import AmdSmiAnalyzerArgs
-from .collector_args import AmdSmiCollectorArgs
+from nodescraper.models import CollectorArgs
 
 
-class AmdSmiPlugin(InBandDataPlugin[AmdSmiDataModel, AmdSmiCollectorArgs, AmdSmiAnalyzerArgs]):
-    """Plugin for collection and analysis of amdsmi data"""
+class AmdSmiCollectorArgs(CollectorArgs):
+    """Collector arguments for AmdSmiPlugin"""
 
-    DATA_MODEL = AmdSmiDataModel
-
-    COLLECTOR = AmdSmiCollector
-
-    COLLECTOR_ARGS = AmdSmiCollectorArgs
-
-    ANALYZER = AmdSmiAnalyzer
-
-    ANALYZER_ARGS = AmdSmiAnalyzerArgs
+    cper_file_path: Optional[str] = None


### PR DESCRIPTION
How to test:

```
(venv) alexbara@smci350-odcdh1-a06-2:~/node-scraper$ node-scraper run-plugins AmdSmiPlugin --collection True --analysis False --cper-file-path /home/alexbara/cpers/corrected-3.cper
  2026-02-04 16:18:41 CST       INFO               nodescraper | Log path: ./scraper_logs_smci350_odcdh1_a06_2_2026_02_04-04_18_41_PM
  2026-02-04 16:18:41 CST       INFO               nodescraper | System Name: smci350-odcdh1-a06-2
  2026-02-04 16:18:41 CST       INFO               nodescraper | System SKU: None
  2026-02-04 16:18:41 CST       INFO               nodescraper | System Platform: None
  2026-02-04 16:18:41 CST       INFO               nodescraper | System location: SystemLocation.LOCAL
  2026-02-04 16:18:41 CST       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2026-02-04 16:18:41 CST       INFO               nodescraper | --------------------------------------------------
  2026-02-04 16:18:41 CST       INFO               nodescraper | Running plugin AmdSmiPlugin
  2026-02-04 16:18:41 CST       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2026-02-04 16:18:41 CST       INFO               nodescraper | Using local shell
  2026-02-04 16:18:41 CST       INFO               nodescraper | Checking OS family
  2026-02-04 16:18:41 CST       INFO               nodescraper | OS Family: LINUX
  2026-02-04 16:18:41 CST       INFO               nodescraper | Running data collector: AmdSmiCollector
  2026-02-04 16:18:41 CST       INFO               nodescraper | amd-smi version: 26.0.0
  2026-02-04 16:18:41 CST       INFO               nodescraper | ROCm version: 7.0.1
  2026-02-04 16:18:42 CST       INFO               nodescraper | Successfully retrieved AFID from CPER file: /home/alexbara/cpers/corrected-3.cper
  2026-02-04 16:18:42 CST       INFO               nodescraper | (AmdSmiPlugin) task completed successfully
  2026-02-04 16:18:42 CST       INFO               nodescraper | Closing connections
  2026-02-04 16:18:42 CST       INFO               nodescraper | Running result collators
  2026-02-04 16:18:42 CST       INFO               nodescraper | Running TableSummary result collator
  2026-02-04 16:18:42 CST       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
| Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
| InBandConnectionManager | OK     | task completed successfully |
+-------------------------+--------+-----------------------------+

+--------------+--------+-------------------------------------+
| Plugin       | Status | Message                             |
+--------------+--------+-------------------------------------+
| AmdSmiPlugin | OK     | Plugin tasks completed successfully |
+--------------+--------+-------------------------------------+

  2026-02-04 16:18:42 CST       INFO               nodescraper | Data written to csv file: ./scraper_logs_smci350_odcdh1_a06_2_2026_02_04-04_18_41_PM/nodescraper.csv
```

or 

```
node-scraper --plugin-configs plugin_config.json
```
where plugin_config.json:
```
{
  "global_args": {},
  "plugins": {
    "AmdSmiPlugin": {
      "collection_args": {
        "cper_file_path": "/path/to/cpers/corrected-3.cper"
      }
    }
  },
  "result_collators": {}
}

```