### PR TITLE
Kernel Analyzer Numa Checks for NS

### DIFF
--- a/nodescraper/plugins/inband/kernel/analyzer_args.py
+++ b/nodescraper/plugins/inband/kernel/analyzer_args.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 #
 ###############################################################################
-from typing import Union
+from typing import Optional, Union
 
 from pydantic import Field, field_validator
 
@@ -33,6 +33,7 @@ from nodescraper.plugins.inband.kernel.kerneldata import KernelDataModel
 
 class KernelAnalyzerArgs(AnalyzerArgs):
     exp_kernel: Union[str, list] = Field(default_factory=list)
+    exp_numa: Optional[int] = None
     regex_match: bool = False
 
     @field_validator("exp_kernel", mode="before")
@@ -61,4 +62,7 @@ class KernelAnalyzerArgs(AnalyzerArgs):
         Returns:
             KernelAnalyzerArgs: instance of analyzer args class
         """
-        return cls(exp_kernel=datamodel.kernel_version)
+        return cls(
+            exp_kernel=datamodel.kernel_version,
+            exp_numa=datamodel.numa_balancing,
+        )

--- a/nodescraper/plugins/inband/kernel/kernel_analyzer.py
+++ b/nodescraper/plugins/inband/kernel/kernel_analyzer.py
@@ -86,21 +86,21 @@ class KernelAnalyzer(DataAnalyzer[KernelDataModel, KernelAnalyzerArgs]):
                 break
 
         if not correct_kernel_version:
-            self.result.message = "unexpected kernel data!"
+            self.result.message = "Kernel mismatch"
             self.result.status = ExecutionStatus.ERROR
             self._log_event(
                 category=EventCategory.OS,
-                description="unexpected kernel version!",
+                description="Kernel mismatch",
                 data={"expected": args.exp_kernel, "actual": data.kernel_version},
                 priority=EventPriority.CRITICAL,
                 console_log=True,
             )
         elif not correct_numa_setting:
-            self.result.message = "unexpected kernel data!"
+            self.result.message = "Unexpected numa_balancing setting!"
             self.result.status = ExecutionStatus.ERROR
             self._log_event(
                 category=EventCategory.OS,
-                description="unexpected numa_balancing setting!",
+                description="Unexpected numa_balancing setting!",
                 data={"expected": args.exp_numa, "actual": data.numa_balancing},
                 priority=EventPriority.CRITICAL,
                 console_log=True,

--- a/nodescraper/plugins/inband/kernel/kernel_analyzer.py
+++ b/nodescraper/plugins/inband/kernel/kernel_analyzer.py
@@ -51,10 +51,20 @@ class KernelAnalyzer(DataAnalyzer[KernelDataModel, KernelAnalyzerArgs]):
         Returns:
             TaskResult: Result of the analysis containing status and message.
         """
-        if not args:
+        correct_kernel_version = False
+        correct_numa_setting = False
+        # skip check if data not provided in config
+        if not args or not args.exp_kernel:
             self.result.message = "Expected kernel not provided"
             self.result.status = ExecutionStatus.NOT_RAN
             return self.result
+
+        if (
+            args.exp_numa is None
+            or data.numa_balancing is None
+            or data.numa_balancing == args.exp_numa
+        ):
+            correct_numa_setting = True
 
         for kernel in args.exp_kernel:
             if args.regex_match:
@@ -69,21 +79,34 @@ class KernelAnalyzer(DataAnalyzer[KernelDataModel, KernelAnalyzerArgs]):
                     )
                     continue
                 if regex_data.match(data.kernel_version):
-                    self.result.message = "Kernel matches expected"
-                    self.result.status = ExecutionStatus.OK
-                    return self.result
+                    correct_kernel_version = True
+                    break
             elif data.kernel_version == kernel:
-                self.result.message = "Kernel matches expected"
-                self.result.status = ExecutionStatus.OK
-                return self.result
+                correct_kernel_version = True
+                break
 
-        self.result.message = "Kernel mismatch!"
-        self.result.status = ExecutionStatus.ERROR
-        self._log_event(
-            category=EventCategory.OS,
-            description=f"Kernel mismatch! Expected: {args.exp_kernel}, actual: {data.kernel_version}",
-            data={"expected": args.exp_kernel, "actual": data.kernel_version},
-            priority=EventPriority.CRITICAL,
-            console_log=True,
-        )
+        if not correct_kernel_version:
+            self.result.message = "unexpected kernel data!"
+            self.result.status = ExecutionStatus.ERROR
+            self._log_event(
+                category=EventCategory.OS,
+                description="unexpected kernel version!",
+                data={"expected": args.exp_kernel, "actual": data.kernel_version},
+                priority=EventPriority.CRITICAL,
+                console_log=True,
+            )
+        elif not correct_numa_setting:
+            self.result.message = "unexpected kernel data!"
+            self.result.status = ExecutionStatus.ERROR
+            self._log_event(
+                category=EventCategory.OS,
+                description="unexpected numa_balancing setting!",
+                data={"expected": args.exp_numa, "actual": data.numa_balancing},
+                priority=EventPriority.CRITICAL,
+                console_log=True,
+            )
+        else:
+            self.result.message = "Kernel matches expected"
+            self.result.status = ExecutionStatus.OK
+
         return self.result

--- a/nodescraper/plugins/inband/kernel/kerneldata.py
+++ b/nodescraper/plugins/inband/kernel/kerneldata.py
@@ -24,9 +24,12 @@
 #
 ###############################################################################
 
+from typing import Optional
+
 from nodescraper.models import DataModel
 
 
 class KernelDataModel(DataModel):
     kernel_info: str
     kernel_version: str
+    numa_balancing: Optional[int] = None

--- a/test/functional/fixtures/kernel_plugin_config.json
+++ b/test/functional/fixtures/kernel_plugin_config.json
@@ -4,6 +4,7 @@
     "KernelPlugin": {
       "analysis_args": {
         "exp_kernel": "5.11-generic",
+        "exp_numa": 0,
         "regex_match": false
       }
     }

--- a/test/unit/plugin/test_kernel_analyzer.py
+++ b/test/unit/plugin/test_kernel_analyzer.py
@@ -93,11 +93,11 @@ def test_invalid_kernel(system_info, model_obj, config):
     result = analyzer.analyze_data(model_obj, args=args)
 
     assert result.status == ExecutionStatus.ERROR
-    assert "unexpected kernel data!" in result.message
+    assert "Kernel mismatch" in result.message
     assert any(
         event.priority == EventPriority.CRITICAL
         and event.category == EventCategory.OS.value
-        and "unexpected kernel version!" in event.description
+        and "Kernel mismatch" in event.description
         for event in result.events
     )
 
@@ -108,7 +108,7 @@ def test_unexpected_kernel(system_info, model_obj):
     result = analyzer.analyze_data(model_obj, args)
 
     assert result.status == ExecutionStatus.ERROR
-    assert "unexpected kernel data!" in result.message
+    assert "Kernel mismatch" in result.message
     assert any(
         event.priority == EventPriority.CRITICAL and event.category == EventCategory.OS.value
         for event in result.events
@@ -143,7 +143,7 @@ def test_mismatch_regex(system_info, model_obj):
     assert len(result.events) == 1
     assert result.events[0].priority == EventPriority.CRITICAL
     assert result.events[0].category == EventCategory.OS.value
-    assert "unexpected kernel version!" in result.events[0].description
+    assert "Kernel mismatch" in result.events[0].description
 
 
 def test_bad_regex(system_info, model_obj):
@@ -158,7 +158,7 @@ def test_bad_regex(system_info, model_obj):
     assert result.events[0].description == "Kernel regex is invalid"
     assert result.events[1].priority == EventPriority.CRITICAL
     assert result.events[1].category == EventCategory.OS.value
-    assert "unexpected kernel version!" in result.events[1].description
+    assert "Kernel mismatch" in result.events[1].description
 
 
 def test_unexpected_numa(system_info, model_obj, config):
@@ -171,11 +171,11 @@ def test_unexpected_numa(system_info, model_obj, config):
     result = analyzer.analyze_data(model_obj, args)
 
     assert result.status == ExecutionStatus.ERROR
-    assert "unexpected kernel data!" in result.message
+    assert "Unexpected numa_balancing setting!" in result.message
     assert any(
         event.priority == EventPriority.CRITICAL
         and event.category == EventCategory.OS.value
-        and "unexpected numa_balancing setting!" in event.description
+        and "Unexpected numa_balancing setting!" in event.description
         for event in result.events
     )
 


### PR DESCRIPTION
json file:
```{
  "global_args": {},
  "plugins": {
    "KernelPlugin": {
      "analysis_args": {
        "exp_kernel": [
          "xyz-sample"
        ],
        "exp_numa": 1,
        "regex_match": false
      }
    }
  },
  "result_collators": {}```

run it with:

`node-scraper --plugin-configs plugin_config.json`

OR

`node-scraper run-plugins KernelPlugin --exp-numa 1 --exp-kernel 5.18.2-mock123`