### PR TITLE
Plugin config to run all plugins: --plugin-config AllPlugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,13 +436,11 @@ This command can be used to generate a reference config that is populated with c
 configurations. Plugins that use analyzer args (where applicable) will be populated with system
 data.
 
-**Generate a reference config using all registered plugins** (built-in `AllPlugins` config):
+**Run all registered plugins (AllPlugins config):**
 ```sh
-node-scraper --gen-reference-config --plugin-configs AllPlugins
+node-scraper --plugin-config AllPlugins
+
 ```
-This runs every plugin with default arguments and writes the resulting reference config to
-`./reference_config.json` (or to the log directory if `--log-path` is set). The subcommand
-`run-plugins` is the default, so it can be omitted.
 
 **Generate a reference config for specific plugins:**
 ```sh

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ options:
   --sys-platform STRING
                         Specify system platform (default: None)
   --plugin-configs [STRING ...]
-                        built-in config names or paths to plugin config JSONs. Available built-in configs: NodeStatus (default: None)
+                        built-in config names or paths to plugin config JSONs. Available built-in configs: AllPlugins, NodeStatus (default: None)
   --system-config STRING
                         Path to system config json (default: None)
   --connection-config STRING
@@ -370,7 +370,11 @@ Below is an example that skips sudo requiring plugins and disables analysis.
 ```
 
 #### Plugin config: **'--plugin-configs' command**
-A plugin config can be used to compare the system data against the config specifications:
+A plugin config can be used to compare the system data against the config specifications.
+Built-in configs include **NodeStatus** (a subset of plugins) and **AllPlugins** (runs every
+registered plugin with default arguments—useful for generating a reference config from the full system).
+
+Using a JSON file:
 ```sh
 node-scraper --plugin-configs plugin_config.json
 ```
@@ -431,7 +435,16 @@ Here is an example of a comprehensive plugin config that specifies analyzer args
 This command can be used to generate a reference config that is populated with current system
 configurations. Plugins that use analyzer args (where applicable) will be populated with system
 data.
-Sample command:
+
+**Generate a reference config using all registered plugins** (built-in `AllPlugins` config):
+```sh
+node-scraper --gen-reference-config --plugin-configs AllPlugins
+```
+This runs every plugin with default arguments and writes the resulting reference config to
+`./reference_config.json` (or to the log directory if `--log-path` is set). The subcommand
+`run-plugins` is the default, so it can be omitted.
+
+**Generate a reference config for specific plugins:**
 ```sh
 node-scraper --gen-reference-config run-plugins BiosPlugin OsPlugin
 

--- a/nodescraper/cli/cli.py
+++ b/nodescraper/cli/cli.py
@@ -52,7 +52,7 @@ from nodescraper.cli.inputargtypes import ModelArgHandler, json_arg, log_path_ar
 from nodescraper.configregistry import ConfigRegistry
 from nodescraper.constants import DEFAULT_LOGGER
 from nodescraper.enums import ExecutionStatus, SystemInteractionLevel, SystemLocation
-from nodescraper.models import SystemInfo
+from nodescraper.models import PluginConfig, SystemInfo
 from nodescraper.pluginexecutor import PluginExecutor
 from nodescraper.pluginregistry import PluginRegistry
 
@@ -171,6 +171,7 @@ def build_parser(
     )
 
     subparsers = parser.add_subparsers(dest="subcmd", help="Subcommands")
+    subparsers.default = "run-plugins"
 
     summary_parser = subparsers.add_parser(
         "summary",
@@ -354,6 +355,14 @@ def main(arg_input: Optional[list[str]] = None):
     plugin_reg = PluginRegistry()
 
     config_reg = ConfigRegistry()
+    # Add synthetic "AllPlugins" config that includes every registered plugin
+    config_reg.configs["AllPlugins"] = PluginConfig(
+        name="AllPlugins",
+        desc="Run all registered plugins with default arguments",
+        global_args={},
+        plugins={name: {} for name in plugin_reg.plugins},
+        result_collators={},
+    )
     parser, plugin_subparser_map = build_parser(plugin_reg, config_reg)
 
     try:


### PR DESCRIPTION
` node-scraper --gen-reference-config --plugin-configs AllPlugins`

t runs every plugin with default args and writes reference_config.json (or into the log directory when --log-path is set),