### PR TITLE
Add netdev mapping command to SysSettingsPlugin

### DIFF
--- a/nodescraper/plugins/inband/sys_settings/sys_settings_collector.py
+++ b/nodescraper/plugins/inband/sys_settings/sys_settings_collector.py
@@ -103,6 +103,8 @@ class SysSettingsCollector(InBandDataCollector[SysSettingsDataModel, SysSettings
 
     CMD = "cat /sys/{}"
     CMD_LS = "ls -1 /sys/{}"
+    CMD_NETDEV_MAP = "ls -l /sys/class/net/*/device"
+    NETDEV_MAP_KEY = "/sys/class/net/*/device"
 
     def collect_data(
         self, args: Optional[SysSettingsCollectorArgs] = None
@@ -188,6 +190,19 @@ class SysSettingsCollector(InBandDataCollector[SysSettingsDataModel, SysSettings
                     priority=EventPriority.WARNING,
                     console_log=True,
                 )
+
+        # Capture netdev -> device symlink mappings for networking topology checks.
+        res_netdev_map = self._run_sut_cmd(self.CMD_NETDEV_MAP, sudo=False)
+        if res_netdev_map.exit_code == 0:
+            readings[self.NETDEV_MAP_KEY] = res_netdev_map.stdout.strip() if res_netdev_map.stdout else ""
+        else:
+            self._log_event(
+                category=EventCategory.OS,
+                description=f"Failed to collect netdev mapping: {self.NETDEV_MAP_KEY}",
+                data={"exit_code": res_netdev_map.exit_code},
+                priority=EventPriority.WARNING,
+                console_log=True,
+            )
 
         if not readings:
             self.result.message = "Sysfs settings not read"

--- a/test/unit/plugin/test_sys_settings_collector.py
+++ b/test/unit/plugin/test_sys_settings_collector.py
@@ -71,7 +71,8 @@ def test_collect_data_success(linux_sys_settings_collector, collection_args):
     assert isinstance(data, SysSettingsDataModel)
     assert data.readings.get(PATH_ENABLED) == "always"
     assert data.readings.get(PATH_DEFRAG) == "madvise"
-    assert "Sysfs collected 2 path(s)" in result.message
+    assert data.readings.get("/sys/class/net/*/device") == "[madvise] always never defer"
+    assert "Sysfs collected 3 path(s)" in result.message
 
 
 def test_collect_data_no_paths_not_ran(linux_sys_settings_collector):
@@ -134,8 +135,8 @@ def test_collect_data_uses_sys_only_command(linux_sys_settings_collector):
     result, data = linux_sys_settings_collector.collect_data(args)
 
     assert result.status == ExecutionStatus.OK
-    assert len(seen_commands) == 1
-    assert seen_commands[0].startswith("cat /sys/")
+    assert "cat /sys/kernel/mm/transparent_hugepage/enabled" in seen_commands
+    assert "ls -l /sys/class/net/*/device" in seen_commands
     assert data.readings.get(PATH_ENABLED) == "value"
 
 
@@ -158,8 +159,29 @@ def test_collect_data_skips_path_with_dotdot(linux_sys_settings_collector):
     result, data = linux_sys_settings_collector.collect_data(args)
 
     assert result.status == ExecutionStatus.OK
-    assert len(seen_commands) == 2
-    assert all(c.startswith("cat /sys/") for c in seen_commands)
+    cat_commands = [c for c in seen_commands if c.startswith("cat /sys/")]
+    assert len(cat_commands) == 2
+    assert "ls -l /sys/class/net/*/device" in seen_commands
     assert data.readings.get("/sys/kernel/mm/transparent_hugepage/enabled") == "safe"
     assert data.readings.get("/sys/kernel/mm/transparent_hugepage/defrag") == "safe"
     assert "/etc" not in str(seen_commands)
+
+
+def test_collect_data_netdev_map_failure_does_not_fail_collection(
+    linux_sys_settings_collector, collection_args
+):
+    """Netdev map failure should not fail if sysfs paths were read."""
+
+    def run_cmd(cmd, **kwargs):
+        if cmd == "ls -l /sys/class/net/*/device":
+            return make_artifact(1, "")
+        if "enabled" in cmd:
+            return make_artifact(0, "[always] madvise never")
+        return make_artifact(0, "[madvise] always never defer")
+
+    linux_sys_settings_collector._run_sut_cmd = run_cmd
+    result, data = linux_sys_settings_collector.collect_data(collection_args)
+
+    assert result.status == ExecutionStatus.OK
+    assert data is not None
+    assert "/sys/class/net/*/device" not in data.readings


### PR DESCRIPTION
Collect netdev-to-device symlink mappings with /sys/class/net/*/device during sys settings collection and cover the new behavior in unit tests.