### PR TITLE
PciePlugin enhancement + plugin utests

### DIFF
--- a/nodescraper/plugins/inband/pcie/pcie_collector.py
+++ b/nodescraper/plugins/inband/pcie/pcie_collector.py
@@ -66,11 +66,13 @@ class PcieCollector(InBandDataCollector[PcieDataModel, None]):
     - `lspci -vvv` : Verbose collection of PCIe data
     - `lspci -vvvt`: Verbose tree view of PCIe data
     - `lspci -PP`: Path view of PCIe data for the GPUs
+    - `lspci -PP -D`: Path view of PCIe data for the GPUs (with domain prefix)
     - If system interaction level is set to STANDARD or higher, the following commands will be run with sudo:
         - `lspci -xxxx`: Hex view of PCIe data for the GPUs
     - otherwise the following commands will be run without sudo:
         - `lspci -x`: Hex view of PCIe data for the GPUs
-    - `lspci -d <vendor_id>:<dev_id>` : Count the number of GPUs in the system with this command
+    - `lspci -d <vendor_id>:` : Detect AMD GPU device IDs in the system
+    - `lspci -PP -D -d <vendor_id>:<dev_id>` : Upstream BDF path for GPUs (with domain prefix)
     - If system interaction level is set to STANDARD or higher, the following commands will be run with sudo:
         - The sudo lspci -xxxx command is used to collect the PCIe configuration space for the GPUs in the system
     - otherwise the following commands will be run without sudo:
@@ -85,10 +87,12 @@ class PcieCollector(InBandDataCollector[PcieDataModel, None]):
     CMD_LSPCI_VERBOSE = "lspci -vvv"
     CMD_LSPCI_VERBOSE_TREE = "lspci -vvvt"
     CMD_LSPCI_PATH = "lspci -PP"
+    CMD_LSPCI_PATH_DOMAIN = "lspci -PP -D"
     CMD_LSPCI_HEX_SUDO = "lspci -xxxx"
     CMD_LSPCI_HEX = "lspci -x"
     CMD_LSPCI_AMD_DEVICES = "lspci -d {vendor_id}: -nn"
     CMD_LSPCI_PATH_DEVICE = "lspci -PP -d {vendor_id}:{dev_id}"
+    CMD_LSPCI_PATH_DEVICE_DOMAIN = "lspci -PP -D -d {vendor_id}:{dev_id}"
 
     def _detect_amd_device_ids(self) -> dict[str, list[str]]:
         """Detect AMD GPU device IDs from the system using lspci.
@@ -149,6 +153,10 @@ class PcieCollector(InBandDataCollector[PcieDataModel, None]):
         """Show lspci with -PP."""
         return self._run_os_cmd(self.CMD_LSPCI_PATH, sudo=sudo)
 
+    def show_lspci_path_domain(self, sudo=True) -> Optional[str]:
+        """Show lspci with -PP -D (path view with domain prefix)."""
+        return self._run_os_cmd(self.CMD_LSPCI_PATH_DOMAIN, sudo=sudo)
+
     def show_lspci_hex(self, bdf: Optional[str] = None, sudo=True) -> Optional[str]:
         """Show lspci with -xxxx."""
         if sudo:
@@ -208,7 +216,10 @@ class PcieCollector(InBandDataCollector[PcieDataModel, None]):
         """
         split_bdf_pos = 0
 
-        bus_path_all_gpus = self._run_os_cmd(f"lspci -PP -d {vendor_id}:{dev_id}", sudo=sudo)
+        bus_path_all_gpus = self._run_os_cmd(
+            self.CMD_LSPCI_PATH_DEVICE_DOMAIN.format(vendor_id=vendor_id, dev_id=dev_id),
+            sudo=sudo,
+        )
         if bus_path_all_gpus is None or bus_path_all_gpus == "":
             self._log_event(
                 category=EventCategory.IO,
@@ -220,6 +231,16 @@ class PcieCollector(InBandDataCollector[PcieDataModel, None]):
         upstream_bdfs: Dict[str, List[str]] = {}
         for bus_path in bus_path_all_gpus.splitlines():
             bus_path_list = (bus_path.split(" ")[split_bdf_pos]).split("/")
+            # With -D, only the first path component carries the domain prefix (e.g. 0001:00:01.1).
+            # Propagate it to all downstream bare BDFs so config space reads hit the correct domain.
+            domain = "0000"
+            for component in bus_path_list:
+                if component.count(":") == 2:
+                    domain = component.split(":")[0]
+                    break
+            bus_path_list = [
+                f"{domain}:{bdf}" if bdf.count(":") == 1 else bdf for bdf in bus_path_list
+            ]
             if upstream_steps_limit is not None and len(bus_path_list) < upstream_steps_limit + 1:
                 # We don't have enough upstream devices to collect
                 self._log_event(
@@ -547,6 +568,7 @@ class PcieCollector(InBandDataCollector[PcieDataModel, None]):
     def _log_pcie_artifacts(
         self,
         lspci_pp: Optional[str],
+        lspci_pp_d: Optional[str],
         lspci_hex: Optional[str],
         lspci_verbose_tree: Optional[str],
         lspci_verbose: Optional[str],
@@ -557,6 +579,7 @@ class PcieCollector(InBandDataCollector[PcieDataModel, None]):
             "lspci_verbose_tree.txt": lspci_verbose_tree,
             "lspci_verbose.txt": lspci_verbose,
             "lspci_pp.txt": lspci_pp,
+            "lspci_pp_d.txt": lspci_pp_d,
         }
         for name, data in name_log_map.items():
             if data is not None:
@@ -626,8 +649,10 @@ class PcieCollector(InBandDataCollector[PcieDataModel, None]):
             lspci_verbose = self.show_lspci_verbose(sudo=use_sudo)
             lspci_verbose_tree = self.show_lspci_verbose_tree(sudo=use_sudo)
             lspci_path = self.show_lspci_path(sudo=use_sudo)
+            lspci_path_domain = self.show_lspci_path_domain(sudo=use_sudo)
             self._log_pcie_artifacts(
                 lspci_pp=lspci_path,
+                lspci_pp_d=lspci_path_domain,
                 lspci_hex=lspci_hex,
                 lspci_verbose_tree=lspci_verbose_tree,
                 lspci_verbose=lspci_verbose,

--- a/nodescraper/plugins/inband/pcie/pcie_data.py
+++ b/nodescraper/plugins/inband/pcie/pcie_data.py
@@ -2009,6 +2009,7 @@ class PcieDataModel(DataModel):
     - lspci_verbose: Verbose collection of PCIe data
     - lspci_verbose_tree: Tree view of PCIe data
     - lspci_path: Path view of PCIe data for the GPUs
+    - lspci_path_domain: Path view of PCIe data for the GPUs (with domain prefix)
     - lspci_hex: Hex view of PCIe data for the GPUs
 
     """

--- a/test/unit/framework/test_pluginconfig.py
+++ b/test/unit/framework/test_pluginconfig.py
@@ -1,0 +1,47 @@
+###############################################################################
+#
+# MIT License
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+#
+###############################################################################
+
+from __future__ import annotations
+
+from nodescraper.models import PluginConfig
+
+
+def test_plugin_config_merge_combines_plugins() -> None:
+    merged = PluginConfig.merge(
+        PluginConfig(
+            name="A",
+            desc="a",
+            plugins={"FooPlugin": {"collection": True, "analysis": False}},
+        ),
+        PluginConfig(
+            name="B",
+            desc="b",
+            plugins={"BarPlugin": {"collection": False, "analysis": True}},
+        ),
+    )
+    assert merged.name == "A"
+    assert merged.desc == "a"
+    assert merged.plugins["FooPlugin"] == {"collection": True, "analysis": False}
+    assert merged.plugins["BarPlugin"] == {"collection": False, "analysis": True}
+
+
+def test_plugin_config_merge_accepts_mappings() -> None:
+    merged = PluginConfig.merge(
+        {
+            "name": "A",
+            "plugins": {"FooPlugin": {}},
+        },
+        PluginConfig(plugins={"BarPlugin": {}}),
+    )
+    assert set(merged.plugins) == {"FooPlugin", "BarPlugin"}
+
+
+def test_plugin_config_coerce() -> None:
+    config = PluginConfig.coerce({"name": "Example", "plugins": {"ExamplePlugin": {}}})
+    assert isinstance(config, PluginConfig)
+    assert config.name == "Example"

--- a/test/unit/plugin/fixtures/pcie_plugin_advanced_config.json
+++ b/test/unit/plugin/fixtures/pcie_plugin_advanced_config.json
@@ -1,0 +1,28 @@
+{
+  "global_args": {},
+  "plugins": {
+    "PciePlugin": {
+      "analysis_args": {
+        "exp_speed": 5,
+        "exp_width": 16,
+        "exp_sriov_count": 8,
+        "exp_gpu_count_override": 4,
+        "exp_max_payload_size": {
+          "29631": 256,
+          "29711": 512
+        },
+        "exp_max_rd_req_size": {
+          "29631": 512,
+          "29711": 1024
+        },
+        "exp_ten_bit_tag_req_en": {
+          "29631": 1,
+          "29711": 0
+        }
+      }
+    }
+  },
+  "result_collators": {},
+  "name": "PciePlugin advanced config",
+  "desc": "Advanced config for testing PciePlugin with device-specific settings"
+}

--- a/test/unit/plugin/fixtures/pcie_plugin_config.json
+++ b/test/unit/plugin/fixtures/pcie_plugin_config.json
@@ -1,0 +1,19 @@
+{
+  "global_args": {},
+  "plugins": {
+    "PciePlugin": {
+      "analysis_args": {
+        "exp_speed": 5,
+        "exp_width": 16,
+        "exp_sriov_count": 8,
+        "exp_gpu_count_override": 4,
+        "exp_max_payload_size": 256,
+        "exp_max_rd_req_size": 512,
+        "exp_ten_bit_tag_req_en": 1
+      }
+    }
+  },
+  "result_collators": {},
+  "name": "PciePlugin config",
+  "desc": "Config for testing PciePlugin"
+}

--- a/test/unit/plugin/test_pcie_collector.py
+++ b/test/unit/plugin/test_pcie_collector.py
@@ -1,0 +1,111 @@
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+###############################################################################
+from unittest.mock import MagicMock
+
+import pytest
+
+from nodescraper.enums.systeminteraction import SystemInteractionLevel
+from nodescraper.plugins.inband.pcie.pcie_collector import PcieCollector
+
+
+@pytest.fixture
+def collector(system_info, conn_mock):
+    return PcieCollector(
+        system_info=system_info,
+        system_interaction_level=SystemInteractionLevel.PASSIVE,
+        connection=conn_mock,
+    )
+
+
+LSPCI_PP_D_MULTI_DOMAIN_OUTPUT = (
+    "0001:00:01.1/00:02.0/00:03.0 Processing accelerators: Advanced Micro Devices, Inc."
+)
+
+LSPCI_PP_D_SINGLE_DOMAIN_OUTPUT = (
+    "00:01.1/00:02.0/00:03.0 Processing accelerators: Advanced Micro Devices, Inc."
+)
+
+
+def test_get_upstream_bdf_uses_lspci_pp_d_command(collector):
+    """Upstream BDF lookup must use lspci -PP -D -d for multi-domain path output."""
+    collector._run_os_cmd = MagicMock(return_value=LSPCI_PP_D_MULTI_DOMAIN_OUTPUT)
+
+    collector._get_upstream_bdf_from_buspath("1002", "74a1")
+
+    collector._run_os_cmd.assert_called_once_with(
+        collector.CMD_LSPCI_PATH_DEVICE_DOMAIN.format(vendor_id="1002", dev_id="74a1"),
+        sudo=True,
+    )
+
+
+def test_get_upstream_bdf_propagates_domain_prefix(collector):
+    """Bare downstream BDFs inherit the domain prefix from the root path component."""
+    collector._run_os_cmd = MagicMock(return_value=LSPCI_PP_D_MULTI_DOMAIN_OUTPUT)
+
+    upstream_bdfs = collector._get_upstream_bdf_from_buspath("1002", "74a1", upstream_steps_limit=2)
+
+    assert upstream_bdfs == {
+        "0001:00:03.0": ["0001:00:03.0", "0001:00:02.0", "0001:00:01.1"],
+    }
+
+
+def test_get_upstream_bdf_defaults_domain_to_0000(collector):
+    """When no domain prefix is present, bare BDFs default to domain 0000."""
+    collector._run_os_cmd = MagicMock(return_value=LSPCI_PP_D_SINGLE_DOMAIN_OUTPUT)
+
+    upstream_bdfs = collector._get_upstream_bdf_from_buspath("1002", "74a1", upstream_steps_limit=1)
+
+    assert upstream_bdfs == {
+        "0000:00:03.0": ["0000:00:03.0", "0000:00:02.0"],
+    }
+
+
+def test_show_lspci_path_domain_uses_correct_command(collector):
+    """Artifact collection runs lspci -PP -D."""
+    collector._run_os_cmd = MagicMock(return_value="0001:00:01.1/00:02.0")
+
+    result = collector.show_lspci_path_domain(sudo=False)
+
+    collector._run_os_cmd.assert_called_once_with(collector.CMD_LSPCI_PATH_DOMAIN, sudo=False)
+    assert result == "0001:00:01.1/00:02.0"
+
+
+def test_log_pcie_artifacts_includes_lspci_pp_d(collector):
+    """Domain-prefixed path view is saved as lspci_pp_d.txt."""
+    collector._log_pcie_artifacts(
+        lspci_pp="00:03.0/00:02.0",
+        lspci_pp_d="0001:00:01.1/0001:00:02.0/0001:00:03.0",
+        lspci_hex="00:",
+        lspci_verbose_tree="tree",
+        lspci_verbose="verbose",
+    )
+
+    artifact_names = {artifact.filename for artifact in collector.result.artifacts}
+    assert "lspci_pp_d.txt" in artifact_names
+    lspci_pp_d = next(
+        artifact for artifact in collector.result.artifacts if artifact.filename == "lspci_pp_d.txt"
+    )
+    assert lspci_pp_d.contents == "0001:00:01.1/0001:00:02.0/0001:00:03.0"

--- a/test/unit/plugin/test_pcie_plugin.py
+++ b/test/unit/plugin/test_pcie_plugin.py
@@ -1,0 +1,140 @@
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+###############################################################################
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nodescraper.models import PluginConfig
+from nodescraper.plugins.inband.pcie.analyzer_args import PcieAnalyzerArgs
+from nodescraper.plugins.inband.pcie.pcie_analyzer import PcieAnalyzer
+from nodescraper.plugins.inband.pcie.pcie_collector import PcieCollector
+from nodescraper.plugins.inband.pcie.pcie_data import PcieDataModel
+from nodescraper.plugins.inband.pcie.pcie_plugin import PciePlugin
+
+
+@pytest.fixture
+def fixtures_dir():
+    return Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def pcie_config_file(fixtures_dir):
+    return fixtures_dir / "pcie_plugin_config.json"
+
+
+@pytest.fixture
+def pcie_advanced_config_file(fixtures_dir):
+    return fixtures_dir / "pcie_plugin_advanced_config.json"
+
+
+def _load_plugin_config(path: Path) -> PluginConfig:
+    return PluginConfig.model_validate(json.loads(path.read_text()))
+
+
+def _pcie_analysis_args(config: PluginConfig) -> PcieAnalyzerArgs:
+    return PcieAnalyzerArgs.model_validate(config.plugins["PciePlugin"]["analysis_args"])
+
+
+def test_pcie_plugin_class_attributes():
+    assert PciePlugin.DATA_MODEL is PcieDataModel
+    assert PciePlugin.COLLECTOR is PcieCollector
+    assert PciePlugin.ANALYZER is PcieAnalyzer
+    assert PciePlugin.ANALYZER_ARGS is PcieAnalyzerArgs
+
+
+def test_pcie_plugin_basic_config_fixture_exists(pcie_config_file):
+    assert pcie_config_file.exists(), f"Config file not found: {pcie_config_file}"
+
+
+def test_pcie_plugin_advanced_config_fixture_exists(pcie_advanced_config_file):
+    assert pcie_advanced_config_file.exists(), f"Config file not found: {pcie_advanced_config_file}"
+
+
+def test_pcie_plugin_with_basic_config(pcie_config_file):
+    """Basic config file analysis_args validate as integer PcieAnalyzerArgs."""
+    config = _load_plugin_config(pcie_config_file)
+    args = _pcie_analysis_args(config)
+
+    assert config.name == "PciePlugin config"
+    assert args.exp_speed == 5
+    assert args.exp_width == 16
+    assert args.exp_sriov_count == 8
+    assert args.exp_gpu_count_override == 4
+    assert args.exp_max_payload_size == 256
+    assert args.exp_max_rd_req_size == 512
+    assert args.exp_ten_bit_tag_req_en == 1
+
+
+def test_pcie_plugin_with_advanced_config(pcie_advanced_config_file):
+    """Advanced config file supports device-specific analyzer args."""
+    config = _load_plugin_config(pcie_advanced_config_file)
+    args = _pcie_analysis_args(config)
+
+    assert config.name == "PciePlugin advanced config"
+    assert args.exp_max_payload_size == {29631: 256, 29711: 512}
+    assert args.exp_max_rd_req_size == {29631: 512, 29711: 1024}
+    assert args.exp_ten_bit_tag_req_en == {29631: 1, 29711: 0}
+
+
+def test_pcie_plugin_combined_configs(pcie_config_file, pcie_advanced_config_file):
+    """Multiple plugin configs merge with later PciePlugin settings taking precedence."""
+    basic = _load_plugin_config(pcie_config_file)
+    advanced = _load_plugin_config(pcie_advanced_config_file)
+
+    merged = PluginConfig.merge(basic, advanced)
+    args = _pcie_analysis_args(merged)
+
+    assert merged.name == "PciePlugin config"
+    assert isinstance(args.exp_max_payload_size, dict)
+    assert args.exp_max_payload_size[29631] == 256
+    assert args.exp_max_payload_size[29711] == 512
+    assert args.exp_max_rd_req_size[29711] == 1024
+
+
+def test_pcie_plugin_run_plugins_entry_present(pcie_config_file):
+    """PciePlugin is configured for collection and analysis via plugin config."""
+    config = _load_plugin_config(pcie_config_file)
+
+    assert "PciePlugin" in config.plugins
+    assert "analysis_args" in config.plugins["PciePlugin"]
+
+
+def test_pcie_plugin_passive_interaction_config(pcie_config_file):
+    """PASSIVE runs use the same analysis args shape as the basic plugin config."""
+    config = _load_plugin_config(pcie_config_file)
+    args = PcieAnalyzerArgs.model_validate(config.plugins["PciePlugin"]["analysis_args"])
+
+    assert args.exp_speed == 5
+    assert args.exp_width == 16
+
+
+def test_pcie_plugin_skip_sudo_config(pcie_config_file):
+    """Skip-sudo scenarios still load the same PciePlugin analysis args from config."""
+    config = _load_plugin_config(pcie_config_file)
+
+    assert config.plugins["PciePlugin"]["analysis_args"]["exp_gpu_count_override"] == 4


### PR DESCRIPTION
## Summary
-Extra PCIe data collection

## Test plan
- [x] `pytest test/unit`
- [x] `pytest test/functional` (if applicable)
- [x] `pre-commit run --all-files`

## Checklist
- [x] Added/updated tests (or explained why not)
- [x] Updated docs/README if behavior changed
- [x] No secrets or credentials committed

Run:
```
alexbara@smci355-ccs-aus-n13-25:~/node-scraper$ node-scraper run-plugins PciePlugin
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Log path: ./scraper_logs_smci355_ccs_aus_n13_25_prov_aus_ccs_cpe_ice_amd_com_2026_06_08-04_42_00_PM
  2026-06-08 16:42:00 UTC       INFO               nodescraper | System Name: <>
  2026-06-08 16:42:00 UTC       INFO               nodescraper | System location: SystemLocation.LOCAL
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2026-06-08 16:42:00 UTC       INFO               nodescraper | --------------------------------------------------
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Running plugin PciePlugin
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Using local shell
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Checking OS family
  2026-06-08 16:42:00 UTC       INFO               nodescraper | OS Family: LINUX
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Running data collector: PcieCollector
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Detected AMD device ID: 1501
  2026-06-08 16:42:00 UTC       INFO               nodescraper | Detected AMD device ID: 75a3
  2026-06-08 16:42:04 UTC       INFO               nodescraper | (PciePlugin) task completed successfully
  2026-06-08 16:42:04 UTC       INFO               nodescraper | Running data analyzer: PcieAnalyzer
  2026-06-08 16:42:04 UTC       INFO               nodescraper | (PciePlugin) task completed successfully
  2026-06-08 16:42:04 UTC       INFO               nodescraper | Closing connections
  2026-06-08 16:42:04 UTC       INFO               nodescraper | Running result collators
  2026-06-08 16:42:04 UTC       INFO               nodescraper | Running TableSummary result collator
  2026-06-08 16:42:04 UTC       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
| Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
| InBandConnectionManager | OK     | task completed successfully |
+-------------------------+--------+-----------------------------+

+------------+--------+-------------------------------------+
| Plugin     | Status | Message                             |
+------------+--------+-------------------------------------+
| PciePlugin | OK     | Plugin tasks completed successfully |
+------------+--------+-------------------------------------+

  2026-06-08 16:42:04 UTC       INFO               nodescraper | Data written to csv file: ./scraper_logs_smci355_ccs_aus_n13_25_prov_aus_ccs_cpe_ice_amd_com_2026_06_08-04_42_00_PM/nodescraper.csv

```