### PR TITLE
SyslogPlugin update: collect rotated messages

### DIFF
--- a/nodescraper/plugins/inband/syslog/syslog_collector.py
+++ b/nodescraper/plugins/inband/syslog/syslog_collector.py
@@ -42,16 +42,28 @@ class SyslogCollector(InBandDataCollector[SyslogData, None]):
     DATA_MODEL = SyslogData
 
     CMD = r"ls -1 /var/log/syslog* 2>/dev/null | grep -E '^/var/log/syslog(\.[0-9]+(\.gz)?)?$' || true"
+    CMD_MESSAGES = r"ls -1 /var/log/messages* 2>/dev/null | grep -E '^/var/log/messages(\.[0-9]+(\.gz)?)?$' || true"
+
+    def _list_log_paths(self, list_cmd: str) -> list[str]:
+        list_res = self._run_sut_cmd(list_cmd, sudo=True)
+        return [p.strip() for p in (list_res.stdout or "").splitlines() if p.strip()]
+
+    @staticmethod
+    def _log_stem(path: str) -> str:
+        if path.startswith("/var/log/messages"):
+            return "messages"
+        return "syslog"
 
     def _collect_syslog_rotations(self) -> list[TextFileArtifact]:
         ret = []
-        list_res = self._run_sut_cmd(self.CMD, sudo=True)
-        paths = [p.strip() for p in (list_res.stdout or "").splitlines() if p.strip()]
+        paths: list[str] = []
+        for list_cmd in (self.CMD, self.CMD_MESSAGES):
+            paths.extend(self._list_log_paths(list_cmd))
         if not paths:
             self._log_event(
                 category=EventCategory.OS,
-                description="No /var/log/syslog files found (including rotations).",
-                data={"list_exit_code": list_res.exit_code},
+                description="No /var/log/syslog or /var/log/messages files found (including rotations).",
+                data={},
                 priority=EventPriority.WARNING,
             )
             return []
@@ -60,11 +72,12 @@ class SyslogCollector(InBandDataCollector[SyslogData, None]):
         collected = []
         for p in paths:
             qp = shell_quote(p)
+            stem = self._log_stem(p)
             if p.endswith(".gz"):
                 cmd = f"gzip -dc {qp} 2>/dev/null || zcat {qp} 2>/dev/null"
                 res = self._run_sut_cmd(cmd, sudo=True, log_artifact=False)
                 if res.exit_code == 0 and res.stdout is not None:
-                    fname = nice_rotated_name(p, "syslog")
+                    fname = nice_rotated_name(p, stem)
                     self.logger.info("Collected syslog log: %s", fname)
                     collected.append(TextFileArtifact(filename=fname, contents=res.stdout))
                     collected_logs.append(fname)
@@ -74,7 +87,7 @@ class SyslogCollector(InBandDataCollector[SyslogData, None]):
                 cmd = f"cat {qp}"
                 res = self._run_sut_cmd(cmd, sudo=True, log_artifact=False)
                 if res.exit_code == 0 and res.stdout is not None:
-                    fname = nice_rotated_name(p, "syslog")
+                    fname = nice_rotated_name(p, stem)
                     self.logger.info("Collected syslog log: %s", fname)
                     collected_logs.append(fname)
                     collected.append(TextFileArtifact(filename=fname, contents=res.stdout))

--- a/test/unit/plugin/test_syslog_collector.py
+++ b/test/unit/plugin/test_syslog_collector.py
@@ -74,6 +74,8 @@ def test_collect_rotations_good_path(monkeypatch, system_info, conn_mock):
     def run_map(cmd, **kwargs):
         if cmd.startswith("ls -1 /var/log/syslog"):
             return DummyRes(command=cmd, stdout=ls_out, exit_code=0)
+        if cmd.startswith("ls -1 /var/log/messages"):
+            return DummyRes(command=cmd, stdout="", exit_code=0)
 
         if cmd.startswith("cat "):
             if "/var/log/syslog.1" in cmd:
@@ -102,7 +104,7 @@ def test_collect_rotations_good_path(monkeypatch, system_info, conn_mock):
 
 def test_collect_rotations_no_files(monkeypatch, system_info, conn_mock):
     def run_map(cmd, **kwargs):
-        if cmd.startswith("ls -1 /var/log/syslog"):
+        if cmd.startswith("ls -1 /var/log/syslog") or cmd.startswith("ls -1 /var/log/messages"):
             return DummyRes(command=cmd, stdout="", exit_code=0)
         return DummyRes(command=cmd, stdout="", exit_code=1)
 
@@ -113,7 +115,7 @@ def test_collect_rotations_no_files(monkeypatch, system_info, conn_mock):
     assert c.result.artifacts == []
 
     assert any(
-        e["description"].startswith("No /var/log/syslog files found")
+        e["description"].startswith("No /var/log/syslog or /var/log/messages files found")
         and getattr(e["priority"], "name", str(e["priority"])) == "WARNING"
         for e in c._events
     )
@@ -125,6 +127,8 @@ def test_collect_rotations_gz_failure(monkeypatch, system_info, conn_mock):
     def run_map(cmd, **kwargs):
         if cmd.startswith("ls -1 /var/log/syslog"):
             return DummyRes(command=cmd, stdout=ls_out, exit_code=0)
+        if cmd.startswith("ls -1 /var/log/messages"):
+            return DummyRes(command=cmd, stdout="", exit_code=0)
         if "gzip -dc" in cmd and "/var/log/syslog.2.gz" in cmd:
             return DummyRes(command=cmd, stdout="", exit_code=1, stderr="gzip: not found")
         return DummyRes(command=cmd, stdout="", exit_code=1)
@@ -149,6 +153,8 @@ def test_collect_data_integration(monkeypatch, system_info, conn_mock):
     def run_map(cmd, **kwargs):
         if cmd.startswith("ls -1 /var/log/syslog"):
             return DummyRes(command=cmd, stdout=ls_out, exit_code=0)
+        if cmd.startswith("ls -1 /var/log/messages"):
+            return DummyRes(command=cmd, stdout="", exit_code=0)
         if cmd.startswith("cat ") and "/var/log/syslog" in cmd:
             return DummyRes(command=cmd, stdout="syslog file content\n", exit_code=0)
         return DummyRes(command=cmd, stdout="", exit_code=1)
@@ -159,3 +165,40 @@ def test_collect_data_integration(monkeypatch, system_info, conn_mock):
     assert isinstance(data, SyslogData)
     assert data.syslog_logs[0].filename == "rotated_syslog.log"
     assert c.result.message == "Syslog data collected"
+
+
+def test_collect_rotations_messages_good_path(monkeypatch, system_info, conn_mock):
+    ls_out = (
+        "\n".join(
+            [
+                "/var/log/messages",
+                "/var/log/messages.1",
+                "/var/log/messages.2.gz",
+            ]
+        )
+        + "\n"
+    )
+
+    def run_map(cmd, **kwargs):
+        if cmd.startswith("ls -1 /var/log/syslog"):
+            return DummyRes(command=cmd, stdout="", exit_code=0)
+        if cmd.startswith("ls -1 /var/log/messages"):
+            return DummyRes(command=cmd, stdout=ls_out, exit_code=0)
+
+        if cmd.startswith("cat "):
+            if "/var/log/messages.1" in cmd:
+                return DummyRes(command=cmd, stdout="messages.1 content\n", exit_code=0)
+            if "/var/log/messages" in cmd:
+                return DummyRes(command=cmd, stdout="messages content\n", exit_code=0)
+
+        if "gzip -dc" in cmd and "/var/log/messages.2.gz" in cmd:
+            return DummyRes(command=cmd, stdout="messages gz content\n", exit_code=0)
+
+        return DummyRes(command=cmd, stdout="", exit_code=1, stderr="unexpected")
+
+    c = get_collector(monkeypatch, run_map, system_info, conn_mock)
+
+    n = c._collect_syslog_rotations()
+    assert n[0].filename == "rotated_messages.log"
+    assert n[1].filename == "rotated_messages.1.log"
+    assert n[2].filename == "rotated_messages.2.gz.log"


### PR DESCRIPTION
## Summary
-Adding collection for var/log/messages

## Test plan
- [ ] `pytest test/unit`
- [ ] `pytest test/functional` (if applicable)
- [ ] `pre-commit run --all-files`

## Checklist
- [ ] Added/updated tests (or explained why not)
- [ ] Updated docs/README if behavior changed
- [ ] No secrets or credentials committed
Run:
```
 alexbara@smci355-ccs-aus-n13-25:~/node-scraper$ node-scraper run-plugins SyslogPlugin
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Log path: ./scraper_logs_smci355_ccs_aus_n13_25_prov_aus_ccs_cpe_ice_amd_com_2026_06_08-04_44_03_PM
  2026-06-08 16:44:03 UTC       INFO               nodescraper | System Name: <>
  2026-06-08 16:44:03 UTC       INFO               nodescraper | System location: SystemLocation.LOCAL
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Initializing connection manager for InBandConnectionManager with default args
  2026-06-08 16:44:03 UTC       INFO               nodescraper | --------------------------------------------------
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Running plugin SyslogPlugin
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Using local shell
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Checking OS family
  2026-06-08 16:44:03 UTC       INFO               nodescraper | OS Family: LINUX
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Running data collector: SyslogCollector
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Collected syslog log: rotated_syslog.log
  2026-06-08 16:44:03 UTC       INFO               nodescraper | Collected syslog log: rotated_syslog.1.log
  2026-06-08 16:44:04 UTC       INFO               nodescraper | Collected syslog log: rotated_syslog.2.gz.log
  2026-06-08 16:44:04 UTC       INFO               nodescraper | Collected syslog log: rotated_syslog.3.gz.log
  2026-06-08 16:44:05 UTC       INFO               nodescraper | Collected syslog log: rotated_syslog.4.gz.log
  2026-06-08 16:44:05 UTC       INFO               nodescraper | Collected syslog log: rotated_messages.log
  2026-06-08 16:44:05 UTC       INFO               nodescraper | Collected syslog log: rotated_messages.1.log
  2026-06-08 16:44:05 UTC       INFO               nodescraper | Collected syslog log: rotated_messages.2.gz.log
  2026-06-08 16:44:05 UTC       INFO               nodescraper | Collected syslog log: rotated_messages.3.gz.log
  2026-06-08 16:44:05 UTC       INFO               nodescraper | Collected syslog log: rotated_messages.4.gz.log
  2026-06-08 16:44:05 UTC       INFO               nodescraper | (SyslogPlugin) Syslog data collected
  2026-06-08 16:44:06 UTC       INFO               nodescraper | Closing connections
  2026-06-08 16:44:06 UTC       INFO               nodescraper | Running result collators
  2026-06-08 16:44:06 UTC       INFO               nodescraper | Running TableSummary result collator
  2026-06-08 16:44:06 UTC       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
| Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
| InBandConnectionManager | OK     | task completed successfully |
+-------------------------+--------+-----------------------------+

+--------------+--------+-------------------------------------+
| Plugin       | Status | Message                             |
+--------------+--------+-------------------------------------+
| SyslogPlugin | OK     | Plugin tasks completed successfully |
+--------------+--------+-------------------------------------+

  2026-06-08 16:44:06 UTC       INFO               nodescraper | Data written to csv file: ./scraper_logs_smci355_ccs_aus_n13_25_prov_aus_ccs_cpe_ice_amd_com_2026_06_08-04_44_03_PM/nodescraper.csv

```