### PR TITLE
AmdSmiPlugin update

### DIFF
--- a/nodescraper/plugins/inband/amdsmi/amdsmi_collector.py
+++ b/nodescraper/plugins/inband/amdsmi/amdsmi_collector.py
@@ -1038,8 +1038,6 @@ class AmdSmiCollector(InBandDataCollector[AmdSmiDataModel, AmdSmiCollectorArgs])
         """Extract current DPM level index from static clock JSON."""
         cur_raw = data.get("current")
         if cur_raw is None:
-            cur_raw = data.get("current_level")
-        if cur_raw is None:
             cur_raw = data.get("current level")
         if isinstance(cur_raw, (int, float)):
             return int(cur_raw)
@@ -1292,10 +1290,14 @@ class AmdSmiCollector(InBandDataCollector[AmdSmiDataModel, AmdSmiCollectorArgs])
         if not isinstance(data, dict):
             return None
 
+        current = self._parse_current_level(data)
         freq_levels_raw = data.get("frequency_levels")
         if isinstance(freq_levels_raw, dict) and freq_levels_raw:
             try:
-                return StaticClockData.model_validate(data)
+                levels = StaticFrequencyLevels.model_validate(freq_levels_raw)
+                return StaticClockData.model_validate(
+                    {"frequency_levels": levels, "current level": current}
+                )
             except ValidationError as err:
                 self._log_event(
                     category=EventCategory.APPLICATION,
@@ -1304,7 +1306,6 @@ class AmdSmiCollector(InBandDataCollector[AmdSmiDataModel, AmdSmiCollectorArgs])
                     priority=EventPriority.WARNING,
                 )
 
-        current = self._parse_current_level(data)
         freqs_raw = data.get("frequency")
         if not isinstance(freqs_raw, list) or not freqs_raw:
             return None
@@ -1341,7 +1342,7 @@ class AmdSmiCollector(InBandDataCollector[AmdSmiDataModel, AmdSmiCollectorArgs])
                 {"Level 0": level0, "Level 1": level1, "Level 2": level2}
             )
 
-            # current_level accepts legacy "current level" / "current" keys via StaticClockData
+            # Use the alias "current level" as defined in the model
             return StaticClockData.model_validate(
                 {"frequency_levels": levels, "current level": current}
             )

--- a/nodescraper/plugins/inband/amdsmi/amdsmi_collector.py
+++ b/nodescraper/plugins/inband/amdsmi/amdsmi_collector.py
@@ -1038,6 +1038,8 @@ class AmdSmiCollector(InBandDataCollector[AmdSmiDataModel, AmdSmiCollectorArgs])
         """Extract current DPM level index from static clock JSON."""
         cur_raw = data.get("current")
         if cur_raw is None:
+            cur_raw = data.get("current_level")
+        if cur_raw is None:
             cur_raw = data.get("current level")
         if isinstance(cur_raw, (int, float)):
             return int(cur_raw)
@@ -1290,14 +1292,10 @@ class AmdSmiCollector(InBandDataCollector[AmdSmiDataModel, AmdSmiCollectorArgs])
         if not isinstance(data, dict):
             return None
 
-        current = self._parse_current_level(data)
         freq_levels_raw = data.get("frequency_levels")
         if isinstance(freq_levels_raw, dict) and freq_levels_raw:
             try:
-                levels = StaticFrequencyLevels.model_validate(freq_levels_raw)
-                return StaticClockData.model_validate(
-                    {"frequency_levels": levels, "current level": current}
-                )
+                return StaticClockData.model_validate(data)
             except ValidationError as err:
                 self._log_event(
                     category=EventCategory.APPLICATION,
@@ -1306,6 +1304,7 @@ class AmdSmiCollector(InBandDataCollector[AmdSmiDataModel, AmdSmiCollectorArgs])
                     priority=EventPriority.WARNING,
                 )
 
+        current = self._parse_current_level(data)
         freqs_raw = data.get("frequency")
         if not isinstance(freqs_raw, list) or not freqs_raw:
             return None
@@ -1342,7 +1341,7 @@ class AmdSmiCollector(InBandDataCollector[AmdSmiDataModel, AmdSmiCollectorArgs])
                 {"Level 0": level0, "Level 1": level1, "Level 2": level2}
             )
 
-            # Use the alias "current level" as defined in the model
+            # current_level accepts legacy "current level" / "current" keys via StaticClockData
             return StaticClockData.model_validate(
                 {"frequency_levels": levels, "current level": current}
             )

--- a/nodescraper/plugins/inband/amdsmi/amdsmidata.py
+++ b/nodescraper/plugins/inband/amdsmi/amdsmidata.py
@@ -523,6 +523,9 @@ class StaticCacheInfoItem(AmdSmiBaseModel):
     na_validator = field_validator("cache_size", mode="before")(na_to_none)
 
 
+_STATIC_CLOCK_FREQ_LEVEL_VALIDATOR_FIELDS = tuple(f"Level_{i}" for i in range(16))
+
+
 class StaticFrequencyLevels(AmdSmiBaseModel):
     """Static clock frequency levels; each level is normalized to ``ValueUnit``."""
 
@@ -534,8 +537,21 @@ class StaticFrequencyLevels(AmdSmiBaseModel):
     Level_0: ValueUnit = Field(..., alias="Level 0")
     Level_1: Optional[ValueUnit] = Field(default=None, alias="Level 1")
     Level_2: Optional[ValueUnit] = Field(default=None, alias="Level 2")
+    Level_3: Optional[ValueUnit] = Field(default=None, alias="Level 3")
+    Level_4: Optional[ValueUnit] = Field(default=None, alias="Level 4")
+    Level_5: Optional[ValueUnit] = Field(default=None, alias="Level 5")
+    Level_6: Optional[ValueUnit] = Field(default=None, alias="Level 6")
+    Level_7: Optional[ValueUnit] = Field(default=None, alias="Level 7")
+    Level_8: Optional[ValueUnit] = Field(default=None, alias="Level 8")
+    Level_9: Optional[ValueUnit] = Field(default=None, alias="Level 9")
+    Level_10: Optional[ValueUnit] = Field(default=None, alias="Level 10")
+    Level_11: Optional[ValueUnit] = Field(default=None, alias="Level 11")
+    Level_12: Optional[ValueUnit] = Field(default=None, alias="Level 12")
+    Level_13: Optional[ValueUnit] = Field(default=None, alias="Level 13")
+    Level_14: Optional[ValueUnit] = Field(default=None, alias="Level 14")
+    Level_15: Optional[ValueUnit] = Field(default=None, alias="Level 15")
 
-    _level_value_unit = field_validator("Level_0", "Level_1", "Level_2", mode="before")(
+    _level_value_unit = field_validator(*_STATIC_CLOCK_FREQ_LEVEL_VALIDATOR_FIELDS, mode="before")(
         coerce_value_unit_input
     )
 

--- a/nodescraper/plugins/inband/amdsmi/amdsmidata.py
+++ b/nodescraper/plugins/inband/amdsmi/amdsmidata.py
@@ -581,10 +581,15 @@ class StaticFrequencyLevels(AmdSmiBaseModel):
 class StaticClockData(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
+        extra="ignore",
     )
     frequency_levels: StaticFrequencyLevels
-
-    current_level: Optional[int] = Field(..., alias="current level")
+    current_level: Optional[int] = Field(
+        default=None,
+        validation_alias=AliasChoices("current level", "current_level", "current"),
+        serialization_alias="current level",
+    )
+    current_frequency: Optional[str] = None
     na_validator = field_validator("current_level", mode="before")(na_to_none)
 
 

--- a/nodescraper/plugins/inband/amdsmi/amdsmidata.py
+++ b/nodescraper/plugins/inband/amdsmi/amdsmidata.py
@@ -525,6 +525,8 @@ class StaticCacheInfoItem(AmdSmiBaseModel):
 
 _STATIC_CLOCK_FREQ_LEVEL_VALIDATOR_FIELDS = tuple(f"Level_{i}" for i in range(16))
 
+_STATIC_FREQ_LEVEL_JSON_KEY_RE = re.compile(r"^level[\s_]*(\d+)\s*$", re.IGNORECASE)
+
 
 class StaticFrequencyLevels(AmdSmiBaseModel):
     """Static clock frequency levels; each level is normalized to ``ValueUnit``."""
@@ -533,6 +535,26 @@ class StaticFrequencyLevels(AmdSmiBaseModel):
         populate_by_name=True,
         extra="forbid",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_level_entries(cls, data: Any) -> Any:
+        """Map amd-smi DPM key spellings to canonical ``Level {n}``, drop non-level keys, ignore index > 15."""
+        if not isinstance(data, dict):
+            return data
+        out: dict[str, Any] = {}
+        for raw_key, val in data.items():
+            n: Optional[int] = None
+            if isinstance(raw_key, int):
+                n = int(raw_key)
+            elif isinstance(raw_key, str):
+                m = _STATIC_FREQ_LEVEL_JSON_KEY_RE.match(raw_key.strip())
+                if m:
+                    n = int(m.group(1))
+            if n is None or n < 0 or n > 15:
+                continue
+            out[f"Level {n}"] = val
+        return out
 
     Level_0: ValueUnit = Field(..., alias="Level 0")
     Level_1: Optional[ValueUnit] = Field(default=None, alias="Level 1")

--- a/nodescraper/plugins/inband/amdsmi/amdsmidata.py
+++ b/nodescraper/plugins/inband/amdsmi/amdsmidata.py
@@ -525,8 +525,6 @@ class StaticCacheInfoItem(AmdSmiBaseModel):
 
 _STATIC_CLOCK_FREQ_LEVEL_VALIDATOR_FIELDS = tuple(f"Level_{i}" for i in range(16))
 
-_STATIC_FREQ_LEVEL_JSON_KEY_RE = re.compile(r"^level[\s_]*(\d+)\s*$", re.IGNORECASE)
-
 
 class StaticFrequencyLevels(AmdSmiBaseModel):
     """Static clock frequency levels; each level is normalized to ``ValueUnit``."""
@@ -535,26 +533,6 @@ class StaticFrequencyLevels(AmdSmiBaseModel):
         populate_by_name=True,
         extra="forbid",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _normalize_level_entries(cls, data: Any) -> Any:
-        """Map amd-smi DPM key spellings to canonical ``Level {n}``, drop non-level keys, ignore index > 15."""
-        if not isinstance(data, dict):
-            return data
-        out: dict[str, Any] = {}
-        for raw_key, val in data.items():
-            n: Optional[int] = None
-            if isinstance(raw_key, int):
-                n = int(raw_key)
-            elif isinstance(raw_key, str):
-                m = _STATIC_FREQ_LEVEL_JSON_KEY_RE.match(raw_key.strip())
-                if m:
-                    n = int(m.group(1))
-            if n is None or n < 0 or n > 15:
-                continue
-            out[f"Level {n}"] = val
-        return out
 
     Level_0: ValueUnit = Field(..., alias="Level 0")
     Level_1: Optional[ValueUnit] = Field(default=None, alias="Level 1")
@@ -581,15 +559,10 @@ class StaticFrequencyLevels(AmdSmiBaseModel):
 class StaticClockData(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
-        extra="ignore",
     )
     frequency_levels: StaticFrequencyLevels
-    current_level: Optional[int] = Field(
-        default=None,
-        validation_alias=AliasChoices("current level", "current_level", "current"),
-        serialization_alias="current level",
-    )
-    current_frequency: Optional[str] = None
+
+    current_level: Optional[int] = Field(..., alias="current level")
     na_validator = field_validator("current_level", mode="before")(na_to_none)
 
 

--- a/test/unit/plugin/test_amdsmi_data.py
+++ b/test/unit/plugin/test_amdsmi_data.py
@@ -450,6 +450,25 @@ def test_static_clock_frequency_levels_json():
     assert clock.frequency_levels.Level_1.value == 900
 
 
+def test_static_clock_mi300_amd_smi_26_json_shape():
+    """ROCm 7.2 / AMD-SMI 26.x clock domains use current_level, current_frequency, and Level N strings."""
+    raw = {
+        "current_level": 0,
+        "current_frequency": "132MHz",
+        "frequency_levels": {
+            "Level 0": "132 MHz",
+            "Level 1": "500 MHz",
+            "Level 2": "2100 MHz",
+        },
+    }
+    clock = StaticClockData.model_validate(raw)
+    assert clock.current_level == 0
+    assert clock.current_frequency == "132MHz"
+    assert clock.frequency_levels.Level_0.value == 132
+    assert clock.frequency_levels.Level_2 is not None
+    assert clock.frequency_levels.Level_2.value == 2100
+
+
 def test_amdsmi_data_model_dummy_metric_round_trip():
     """Full dummy metric payload validates and preserves key ROCm 7.13 fields."""
     metric = AmdSmiMetric.model_validate(dummy_metric_dict())

--- a/test/unit/plugin/test_amdsmi_data.py
+++ b/test/unit/plugin/test_amdsmi_data.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 #
 ###############################################################################
-"""Unit tests for amd-smi pydantic models (ROCm 7.13 / legacy JSON shapes)."""
+"""Unit tests for amd-smi pydantic models (legacy JSON, ROCm 7.2+ / AMD-SMI 26.2+)."""
 
 from typing import Any, Optional
 
@@ -339,6 +339,36 @@ def test_static_frequency_levels_optional_levels():
     assert levels.Level_0.value == 500
     assert levels.Level_1 is not None and levels.Level_1.value == 900
     assert levels.Level_2 is not None and levels.Level_2.value == 1300
+
+
+def test_static_frequency_levels_accepts_level_three_plus():
+    """ROCm 7.2+ / AMD-SMI 26.2+ may expose additional DPM levels (e.g. Level 3)."""
+    levels = StaticFrequencyLevels.model_validate(
+        {
+            "Level 0": "400 MHz",
+            "Level 1": "800 MHz",
+            "Level 2": "1000 MHz",
+            "Level 3": "1143 MHz",
+        }
+    )
+    assert levels.Level_3 is not None
+    assert levels.Level_3.value == 1143
+    assert levels.Level_3.unit == "MHz"
+
+
+def test_static_frequency_levels_legacy_amd_smi_three_levels_only():
+    """Legacy static JSON: only Level 0–2 (no Level 3+ keys)."""
+    levels = StaticFrequencyLevels.model_validate(
+        {
+            "Level 0": {"value": 500, "unit": "MHz"},
+            "Level 1": "900 MHz",
+            "Level 2": "1300 MHz",
+        }
+    )
+    assert levels.Level_0.value == 500
+    assert levels.Level_2 is not None and levels.Level_2.value == 1300
+    assert levels.Level_3 is None
+    assert levels.Level_15 is None
 
 
 def test_static_limit_legacy_max_power():

--- a/test/unit/plugin/test_amdsmi_data.py
+++ b/test/unit/plugin/test_amdsmi_data.py
@@ -371,35 +371,6 @@ def test_static_frequency_levels_legacy_amd_smi_three_levels_only():
     assert levels.Level_15 is None
 
 
-def test_static_frequency_levels_accepts_amd_smi_key_spelling_variants():
-    """ROCm / AMD-SMI JSON may use LEVEL_N / Level0 style keys instead of ``Level N``."""
-    levels = StaticFrequencyLevels.model_validate(
-        {
-            "LEVEL_0": "400 MHz",
-            "level_1": "800 MHz",
-            "Level2": "1000 MHz",
-            "Level 3": "1143 MHz",
-        }
-    )
-    assert levels.Level_0.value == 400
-    assert levels.Level_1 is not None and levels.Level_1.value == 800
-    assert levels.Level_2 is not None and levels.Level_2.value == 1000
-    assert levels.Level_3 is not None and levels.Level_3.value == 1143
-
-
-def test_static_frequency_levels_drops_unknown_keys_and_high_indices():
-    """Non-level keys are ignored; DPM indices above 15 are dropped (model stores 0–15 only)."""
-    levels = StaticFrequencyLevels.model_validate(
-        {
-            "Level 0": "100 MHz",
-            "num_states": 99,
-            "Level 16": "9999 MHz",
-        }
-    )
-    assert levels.Level_0.value == 100
-    assert levels.Level_1 is None
-
-
 def test_static_limit_legacy_max_power():
     """Legacy flat max_power field still resolves."""
     limit = StaticLimit.model_validate(DUMMY_LIMIT_LEGACY)
@@ -448,25 +419,6 @@ def test_static_clock_frequency_levels_json():
     assert clock.frequency_levels.Level_0.value == 500
     assert clock.frequency_levels.Level_1 is not None
     assert clock.frequency_levels.Level_1.value == 900
-
-
-def test_static_clock_mi300_amd_smi_26_json_shape():
-    """ROCm 7.2 / AMD-SMI 26.x clock domains use current_level, current_frequency, and Level N strings."""
-    raw = {
-        "current_level": 0,
-        "current_frequency": "132MHz",
-        "frequency_levels": {
-            "Level 0": "132 MHz",
-            "Level 1": "500 MHz",
-            "Level 2": "2100 MHz",
-        },
-    }
-    clock = StaticClockData.model_validate(raw)
-    assert clock.current_level == 0
-    assert clock.current_frequency == "132MHz"
-    assert clock.frequency_levels.Level_0.value == 132
-    assert clock.frequency_levels.Level_2 is not None
-    assert clock.frequency_levels.Level_2.value == 2100
 
 
 def test_amdsmi_data_model_dummy_metric_round_trip():

--- a/test/unit/plugin/test_amdsmi_data.py
+++ b/test/unit/plugin/test_amdsmi_data.py
@@ -371,6 +371,35 @@ def test_static_frequency_levels_legacy_amd_smi_three_levels_only():
     assert levels.Level_15 is None
 
 
+def test_static_frequency_levels_accepts_amd_smi_key_spelling_variants():
+    """ROCm / AMD-SMI JSON may use LEVEL_N / Level0 style keys instead of ``Level N``."""
+    levels = StaticFrequencyLevels.model_validate(
+        {
+            "LEVEL_0": "400 MHz",
+            "level_1": "800 MHz",
+            "Level2": "1000 MHz",
+            "Level 3": "1143 MHz",
+        }
+    )
+    assert levels.Level_0.value == 400
+    assert levels.Level_1 is not None and levels.Level_1.value == 800
+    assert levels.Level_2 is not None and levels.Level_2.value == 1000
+    assert levels.Level_3 is not None and levels.Level_3.value == 1143
+
+
+def test_static_frequency_levels_drops_unknown_keys_and_high_indices():
+    """Non-level keys are ignored; DPM indices above 15 are dropped (model stores 0–15 only)."""
+    levels = StaticFrequencyLevels.model_validate(
+        {
+            "Level 0": "100 MHz",
+            "num_states": 99,
+            "Level 16": "9999 MHz",
+        }
+    )
+    assert levels.Level_0.value == 100
+    assert levels.Level_1 is None
+
+
 def test_static_limit_legacy_max_power():
     """Legacy flat max_power field still resolves."""
     limit = StaticLimit.model_validate(DUMMY_LIMIT_LEGACY)


### PR DESCRIPTION
## Summary
-Extend StaticFrequencyLevels to accept DPM levels 0–15
-Update for amdsmi 26.x

## Test plan
- [x] `pytest test/unit`
- [x] `pytest test/functional` (if applicable)
- [x] `pre-commit run --all-files`

## Checklist
- [x] Added/updated tests (or explained why not)
- [x] Updated docs/README if behavior changed
- [x] No secrets or credentials committed
Before:
```
 alexbara@banff-cyxtera-s72-1:~/node-scraper$ node-scraper run-plugins AmdSmiPlugin
  2026-06-22 09:52:41 CDT       INFO               nodescraper | Log path: ./scraper_logs_banff_cyxtera_s72_1_2026_06_22-09_52_41_AM
...
  2026-06-22 09:52:41 CDT       INFO               nodescraper | Running data collector: AmdSmiCollector
  2026-06-22 09:52:42 CDT       INFO               nodescraper | amd-smi version: 26.2.2
  2026-06-22 09:52:42 CDT       INFO               nodescraper | ROCm version: 7.2.1
  2026-06-22 09:52:47 CDT    WARNING               nodescraper | (AmdSmiPlugin) task completed with warnings (8 warnings: Failed to parse static clock frequency_levels (x8))
  2026-06-22 09:52:47 CDT       INFO               nodescraper | Running data analyzer: AmdSmiAnalyzer
  2026-06-22 09:52:47 CDT      ERROR               nodescraper | GPU: 7 has 4 L0 recoveries
  2026-06-22 09:52:47 CDT       INFO               nodescraper | Expected XGMI link speed not set; skipping XGMI link speed analysis
  2026-06-22 09:52:47 CDT      ERROR               nodescraper | (AmdSmiPlugin) task detected errors (1 errors: GPU: 7 has 4 L0 recoveries)
  2026-06-22 09:52:47 CDT       INFO               nodescraper | Closing connections
  2026-06-22 09:52:47 CDT       INFO               nodescraper | Running result collators
  2026-06-22 09:52:47 CDT       INFO               nodescraper | Running TableSummary result collator
  2026-06-22 09:52:47 CDT       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
| Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
| InBandConnectionManager | OK     | task completed successfully |
+-------------------------+--------+-----------------------------+

+--------------+--------+-------------------------------------------------------------------------------+
| Plugin       | Status | Message                                                                       |
+--------------+--------+-------------------------------------------------------------------------------+
| AmdSmiPlugin | ERROR  | Collection warning: task completed with warnings (8 warnings: Failed to parse |
|              |        | static clock frequency_levels (x8)); Analysis error: task detected errors (1  |
|              |        | errors: GPU: 7 has 4 L0 recoveries)                                           |
+--------------+--------+-------------------------------------------------------------------------------+

```
After
```
node-scraper$ node-scraper run-plugins AmdSmiPlugin
...
  2026-06-22 10:29:51 CDT       INFO               nodescraper | Running plugin AmdSmiPlugin
  2026-06-22 10:29:51 CDT       INFO               nodescraper | Initializing connection: InBandConnectionManager
  2026-06-22 10:29:51 CDT       INFO               nodescraper | Using local shell
  2026-06-22 10:29:51 CDT       INFO               nodescraper | Checking OS family
  2026-06-22 10:29:51 CDT       INFO               nodescraper | OS Family: LINUX
  2026-06-22 10:29:51 CDT       INFO               nodescraper | Running data collector: AmdSmiCollector
  2026-06-22 10:29:51 CDT       INFO               nodescraper | amd-smi version: 26.2.2
  2026-06-22 10:29:51 CDT       INFO               nodescraper | ROCm version: 7.2.1
  2026-06-22 10:29:57 CDT       INFO               nodescraper | (AmdSmiPlugin) task completed successfully
  2026-06-22 10:29:57 CDT       INFO               nodescraper | Running data analyzer: AmdSmiAnalyzer
  2026-06-22 10:29:57 CDT      ERROR               nodescraper | GPU: 7 has 4 L0 recoveries
  2026-06-22 10:29:57 CDT       INFO               nodescraper | Expected XGMI link speed not set; skipping XGMI link speed analysis
  2026-06-22 10:29:57 CDT      ERROR               nodescraper | (AmdSmiPlugin) task detected errors (1 errors: GPU: 7 has 4 L0 recoveries)
  2026-06-22 10:29:57 CDT       INFO               nodescraper | Closing connections
  2026-06-22 10:29:57 CDT       INFO               nodescraper | Running result collators
  2026-06-22 10:29:57 CDT       INFO               nodescraper | Running TableSummary result collator
  2026-06-22 10:29:57 CDT       INFO               nodescraper |

+-------------------------+--------+-----------------------------+
| Connection              | Status | Message                     |
+-------------------------+--------+-----------------------------+
| InBandConnectionManager | OK     | task completed successfully |
+-------------------------+--------+-----------------------------+

+--------------+--------+-----------------------------------------------------------------------------+
| Plugin       | Status | Message                                                                     |
+--------------+--------+-----------------------------------------------------------------------------+
| AmdSmiPlugin | ERROR  | Analysis error: task detected errors (1 errors: GPU: 7 has 4 L0 recoveries) |
+--------------+--------+-----------------------------------------------------------------------------+

  2026-06-22 10:29:57 CDT       INFO               nodescraper | Data written to csv file: ./scraper_logs_banff_cyxtera_s72_1_2026_06_22-10_29_51_AM/nodescraper.csv

```