### PR TITLE
feature/migrate dev setup to uv

### DIFF
--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for pre-commit to work
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
       # python:3.9 image has no git; pre-commit requires it.
       - name: Install git
         run: |

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for pre-commit to work
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
       # python:3.9 image has no git; pre-commit requires it.
       - name: Install git

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
     - name: Install xmllint
       run: |

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Install xmllint
       run: |
         apt-get update

--- a/.github/workflows/release-trusted-publisher.yml
+++ b/.github/workflows/release-trusted-publisher.yml
@@ -88,14 +88,11 @@ jobs:
           git tag ${{ steps.next_version.outputs.version }}
           git push origin ${{ steps.next_version.outputs.version }}
 
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Build package
-        run: |
-          python -m build
+        run: uv build
 
       - name: Upload to PyPI using Trusted Publisher
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-trusted-publisher.yml
+++ b/.github/workflows/release-trusted-publisher.yml
@@ -89,7 +89,7 @@ jobs:
           git push origin ${{ steps.next_version.outputs.version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
       - name: Build package
         run: uv build

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
     - name: Install xmllint
       run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Install xmllint
       run: |
         apt-get update

--- a/.github/workflows/update-plugin-docs.yml
+++ b/.github/workflows/update-plugin-docs.yml
@@ -30,6 +30,9 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Install dependencies
       run: ./dev-setup.sh
 

--- a/.github/workflows/update-plugin-docs.yml
+++ b/.github/workflows/update-plugin-docs.yml
@@ -31,7 +31,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
     - name: Install dependencies
       run: ./dev-setup.sh

--- a/README.md
+++ b/README.md
@@ -3,26 +3,31 @@ Node Scraper is a tool which performs automated data collection and analysis for
 system debug. For details on what data is collected and analyzed, see the [plugin reference table](docs/PLUGIN_DOC.md).
 
 ## Table of Contents
-- [Installation](#installation)
-  - [Install from PyPI](#install-from-pypi)
-  - [Install from Source](#install-from-source)
-- [CLI Usage](#cli-usage)
-  - [Execution Methods](#execution-methods)
-    - [Example: Remote Execution](#example-remote-execution)
-    - [Example: connection_config.json](#example-connection_configjson)
-  - [Subcommands](#subcommands)
-    - ['describe' subcommand](#describe-subcommand)
-    - ['run-plugins' sub command](#run-plugins-sub-command)
-    - ['gen-plugin-config' sub command](#gen-plugin-config-sub-command)
-    - ['compare-runs' subcommand](#compare-runs-subcommand)
-    - ['summary' sub command](#summary-sub-command)
-- [Configs](#configs)
-  - [Global args](#global-args)
-  - [Plugin config: `--plugin-configs` command](#plugin-config---plugin-configs-command)
-  - [Reference config: `gen-reference-config` command](#reference-config-gen-reference-config-command)
-- **Extending Node Scraper (integration & external plugins)** → See [EXTENDING.md](EXTENDING.md)
-- **Full view of the plugins with the associated collectors & analyzers as well as the commands
-invoked by collectors** -> See [docs/PLUGIN_DOC.md](docs/PLUGIN_DOC.md)
+- [Node Scraper](#node-scraper)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+    - [Install from PyPI](#install-from-pypi)
+    - [Install from Source](#install-from-source)
+    - [1. Install uv](#1-install-uv)
+    - [2. Virtual Environment (Optional)](#2-virtual-environment-optional)
+    - [3. Install from Source (Required)](#3-install-from-source-required)
+    - [4. Git Hooks (Optional)](#4-git-hooks-optional)
+  - [CLI Usage](#cli-usage)
+    - [Execution Methods](#execution-methods)
+      - [Example: Remote Execution](#example-remote-execution)
+        - [Example: connection\_config.json](#example-connection_configjson)
+    - [Subcommands](#subcommands)
+      - [**'describe' subcommand**](#describe-subcommand)
+      - [**'run-plugins' sub command**](#run-plugins-sub-command)
+      - [**'gen-plugin-config' sub command**](#gen-plugin-config-sub-command)
+      - [**'compare-runs' subcommand**](#compare-runs-subcommand)
+      - [**'show-redfish-oem-allowable' subcommand**](#show-redfish-oem-allowable-subcommand)
+      - [**RedfishEndpointPlugin**](#redfishendpointplugin)
+      - [**'summary' sub command**](#summary-sub-command)
+    - [Configs](#configs)
+      - [Global args](#global-args)
+      - [Plugin config: **'--plugin-configs' command**](#plugin-config---plugin-configs-command)
+      - [Reference config: **'gen-reference-config' command**](#reference-config-gen-reference-config-command)
 
 ## Installation
 ### Install from PyPI
@@ -30,6 +35,12 @@ Node Scraper is published on [PyPI](https://pypi.org/project/amd-node-scraper/) 
 
 ```sh
 pip install amd-node-scraper
+```
+
+With [uv](https://docs.astral.sh/uv/):
+
+```sh
+uv pip install amd-node-scraper
 ```
 
 Use a virtual environment if you prefer. After installation, confirm the CLI is available:
@@ -40,8 +51,8 @@ node-scraper --help
 
 ### Install from Source
 Node Scraper requires Python 3.9+ for installation. After cloning this repository,
-call dev-setup.sh script with 'source'. This script creates an editable install of Node Scraper in
-a python virtual environment and also configures the pre-commit hooks for the project.
+run `dev-setup.sh` with `source`. This script uses [uv](https://docs.astral.sh/uv/) to create a
+Python 3.9+ virtual environment, perform an editable install, and configure pre-commit hooks.
 
 ```sh
 source dev-setup.sh
@@ -49,20 +60,31 @@ source dev-setup.sh
 
 Alternatively, follow these manual steps:
 
-### 1. Virtual Environment (Optional)
+### 1. Install uv
 ```sh
-python3 -m venv venv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+### 2. Virtual Environment (Optional)
+```sh
+uv venv venv --python 3.9
 source venv/bin/activate
 ```
-On Debian/Ubuntu, you may need: `sudo apt install python3-venv`
+On Debian/Ubuntu without uv, you can use `python3.9 -m venv venv` instead.
 
-### 2. Install from Source (Required)
+### 3. Install from Source (Required)
 ```sh
-python3 -m pip install --editable .[dev] --upgrade
+uv pip install -e ".[dev]"
 ```
 This installs Node Scraper in editable mode with development dependencies. To verify: `node-scraper --help`
 
-### 3. Git Hooks (Optional)
+Equivalent using pip:
+
+```sh
+python3 -m pip install --editable .[dev] --upgrade
+```
+
+### 4. Git Hooks (Optional)
 ```sh
 pre-commit install
 ```

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
 
-# Create venv if not already present
-if [ ! -d "venv" ]; then
-    python3 -m venv venv
+if ! which uv >/dev/null 2>&1; then
+    if ! which curl >/dev/null 2>&1; then
+        wget -qO- https://astral.sh/uv/install.sh | sh
+    else
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Use system certificate store so uv works behind corporate SSL proxies
+export UV_SYSTEM_CERTS=1
+
+# Create venv if not already present or if Python version is below 3.9
+if [ ! -d "venv" ] || ! venv/bin/python -c 'import sys; exit(0 if sys.version_info >= (3, 9) else 1)' 2>/dev/null; then
+    uv venv venv --python python3 --no-python-downloads
 fi
 
 # Activate the desired venv
 source venv/bin/activate
 
-python3 -m pip install --editable .[dev] --upgrade
+uv pip install -e ".[dev]"
 
 # Only install pre-commit hooks if not in CI environment
-if [ -z "$CI" ]; then
+if [ -z "${CI:-}" ]; then
     pre-commit install
 fi


### PR DESCRIPTION
## Summary
Migrate dev setup to use uv, Currently only enforces python ver 3.9+ but can be changed to demand specific version.
Setuptools security issue still an issue until we can migrate to python 3.10+ and setuptools ver 83.0.0+.

## Test plan
- [x] `pytest test/unit`
- [] `pytest test/functional` (if applicable)
- [x] `pre-commit run --all-files`

## Checklist
- [x] Added/updated tests (or explained why not)
- [x] Updated docs/README if behavior changed
- [x] No secrets or credentials committed
